### PR TITLE
Sign commits performed in Action workflow

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -72,24 +72,23 @@ jobs:
           } | sort -u > "$MANIFEST"
           rm -f "$cm_manifest"
 
-      - name: Commit and push if changed
+      - name: Check for changes and bump version
+        id: check
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           git add -A skills/
           if git diff --cached --quiet; then
             echo "No changes detected."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
           # Bump patch version in plugin manifests
           for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json; do
             if [ -f "$f" ]; then
               jq '.version |= (split(".") | .[2] = (.[2] | tonumber + 1 | tostring) | join("."))' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
-              git add "$f"
             fi
           done
 
@@ -104,5 +103,14 @@ jobs:
           [ -n "$CM_TAG" ] && VERSIONS="${VERSIONS:+$VERSIONS, }context-mill@$CM_TAG"
           VERSIONS="${VERSIONS:-latest}"
 
-          git commit -m "chore: sync skills ($VERSIONS)"
-          git push
+          echo "commit_message=chore: sync skills ($VERSIONS)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        if: steps.check.outputs.has_changes == 'true'
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: ${{ steps.check.outputs.commit_message }}
+          repo: ${{ github.repository }}
+          branch: ${{ github.event.inputs.ref || github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This will allow us to enforce signed commits in this repo, which I'm trying to roll out to our entire org (starting with repos that publish assets).

@skoob13 be sure to set up commit signing on your laptop, if you haven't yet. Instructions at https://posthog.com/handbook/engineering/security#commit-signing