### PR TITLE
Revise README for better installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PostHog AI Plugin
+# PostHog AI plugin
 
 Official PostHog plugin for AI clients. Access your analytics, feature flags, experiments, and error tracking directly from your AI coding tool.
 
@@ -6,9 +6,19 @@ Official PostHog plugin for AI clients. Access your analytics, feature flags, ex
 
 ### Claude Code
 
-```bash
-claude plugin install posthog
-```
+1. Install the plugin:
+    ```bash
+    claude plugin install posthog
+    ```
+
+2. Authenticate via OAuth:
+    ```bash
+    # Just enter Claude Code anywhere
+    claude
+    # Then, use the /mcp command within Claude, select plugin:posthog:posthog, and press Enter
+    /mcp
+    ```
+    Then follow the browser prompts to log into PostHog.
 
 ### Cursor
 
@@ -20,19 +30,19 @@ Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add man
 gemini extensions install https://github.com/PostHog/ai-plugin
 ```
 
-### Manual installation
+## How to develop
 
 1. Clone and install the plugin:
-```bash
-git clone https://github.com/PostHog/ai-plugin
-claude --plugin-dir ./ai-plugin
-```
+    ```bash
+    git clone https://github.com/PostHog/ai-plugin
+    claude --plugin-dir ./ai-plugin
+    ```
 
 2. Authenticate via OAuth:
-```
-/mcp
-```
-Then follow the browser prompts to log in to PostHog.
+    ```
+    /mcp
+    ```
+    Then follow the browser prompts to log into PostHog.
 
 ## Features
 
@@ -62,7 +72,7 @@ This plugin provides access to 27+ PostHog tools across these categories:
 - `/posthog:search` - Search across all PostHog entities
 - `/posthog:workspace` - Manage organizations and projects
 
-## Example Usage
+## Example usage
 
 ```
 > What feature flags do I have?


### PR DESCRIPTION
I got word from a user the installation process of the PostHog CC plugin didn't work for them because of auth.
Turns out they were right, and just `claude plugin install posthog` isn't enough - it's also necessary to manually initiate OAuth.
README should explain this.
I also looked at posthog.com if the Claude Code plugin is explained anywhere there, but I didn't find it - let me know if I missed it there.