### PR TITLE
Add Codex plugin support with installation instructions

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "posthog",
+  "version": "1.0.2",
+  "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Codex",
+  "author": {
+    "name": "PostHog",
+    "email": "hey@posthog.com",
+    "url": "https://posthog.com"
+  },
+  "homepage": "https://posthog.com/docs/model-context-protocol",
+  "repository": "https://github.com/PostHog/ai-plugin",
+  "license": "MIT",
+  "keywords": [
+    "analytics",
+    "feature-flags",
+    "experiments",
+    "error-tracking",
+    "a/b-testing",
+    "surveys",
+    "dashboards",
+    "llm-analytics"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "PostHog",
+    "shortDescription": "Analytics, feature flags, experiments, and error tracking",
+    "longDescription": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Codex. Query your data, manage flags, run A/B tests, and debug errors without leaving your editor.",
+    "developerName": "PostHog",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://posthog.com",
+    "privacyPolicyURL": "https://posthog.com/privacy",
+    "termsOfServiceURL": "https://posthog.com/terms",
+    "defaultPrompt": [
+      "Show me all my feature flags",
+      "What errors are affecting the most users?",
+      "How many users signed up this week?"
+    ],
+    "brandColor": "#F9BD2B",
+    "logo": "./assets/logo.svg"
+  }
+}

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -87,7 +87,7 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
           # Bump patch version in plugin manifests
-          for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json gemini-extension.json; do
+          for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .codex-plugin/plugin.json gemini-extension.json; do
             if [ -f "$f" ]; then
               jq '.version |= (split(".") | .[2] = (.[2] | tonumber + 1 | tostring) | join("."))' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
             fi

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ claude plugin install posthog
 
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add manually in Cursor Settings > Plugins.
 
+### Codex
+
+```bash
+codex plugin install posthog
+```
+
 ### Gemini CLI
 
 ```bash


### PR DESCRIPTION
This pull request adds support for the Codex platform by introducing a new plugin configuration file and updating the build process. The changes include:

- Added `.codex-plugin/plugin.json` with PostHog plugin metadata, capabilities, and interface configuration for Codex integration
- Updated the GitHub Actions workflow to include the Codex plugin manifest in the automated version bumping process
- Added installation instructions for Codex users in the README

The Codex plugin configuration enables users to access PostHog analytics, feature flags, experiments, and error tracking directly from the Codex editor with both read and write capabilities.