### PR TITLE
chore(phai): strip version field from context-mill skills during sync

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -63,6 +63,7 @@ jobs:
             mkdir -p "skills/$skill_name"
             unzip -q -o "$inner_zip" -d "skills/$skill_name"
             find "skills/$skill_name" -name 'SKILL.md' -type f -exec sed -i 's/^\(name: *\)omnibus-/\1/' {} +
+            find "skills/$skill_name" -name 'SKILL.md' -type f -exec sed -i '/^  version: .*/d' {} +
           done < <(find "$tmp_cm" -name 'omnibus-*.zip' -type f)
           rm -rf "$tmp_cm"
 


### PR DESCRIPTION
Strips `version` fields from the frontmatter.