### PR TITLE
Switch to GitHub App to fix PR checks

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -10,14 +10,17 @@ on:
         required: false
         default: ''
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   sync-skills:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.GH_APP_AI_PLUGIN_RELEASER_APP_ID }}
+          private-key: ${{ secrets.GH_APP_AI_PLUGIN_RELEASER_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -25,7 +28,7 @@ jobs:
 
       - name: Download skills from PostHog release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release download agent-skills-latest \
             --repo PostHog/posthog \
@@ -77,7 +80,7 @@ jobs:
       - name: Check for changes and bump version
         id: check
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git add -A skills/ commands/*.toml gemini-extension.json
           if git diff --cached --quiet; then
@@ -132,12 +135,12 @@ jobs:
           repo: ${{ github.repository }}
           branch: ${{ steps.branch.outputs.branch }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create PR with auto-merge
         if: steps.check.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           COMMIT_MESSAGE: ${{ steps.check.outputs.commit_message }}
           BASE_REF: ${{ steps.branch.outputs.base }}
           HEAD_REF: ${{ steps.branch.outputs.branch }}


### PR DESCRIPTION
Now when the "sync skills" workflow creates a PR ([example](https://github.com/PostHog/ai-plugin/pull/18)), checks will properly run against it.