### PR TITLE
ci(posthog-ai-plugin): add HOL ai-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -31,6 +31,5 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
 
       - name: Run scanner
-        uses: hashgraph-online/codex-plugin-scanner@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
         with:
-          args: scan --fail-on critical

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,24 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+        with:
+          plugin_dir: "."

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,24 +1,36 @@
-name: Codex Plugin Quality Gate
+name: Codex Plugin Scanner CI
 
 on:
   push:
     branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
   pull_request:
     branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+
+permissions:
+  contents: read
 
 concurrency:
-  group: codex-plugin-scanner-${{ github.ref }}
+  group: scanner-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   scan:
+    name: Plugin Scanner
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Codex plugin scanner
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Run scanner
+        uses: hashgraph-online/codex-plugin-scanner@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
         with:
-          plugin_dir: "."
+          args: scan --fail-on critical


### PR DESCRIPTION
I opened this to add a scanner-only check for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- The repo already looks like a reasonable fit for a small validation pass

The current local scan came back 85/100 (grade B).

This PR only adds the scanner workflow. It does not touch runtime code or release behavior.
If you would rather wire it in a different workflow file, I can adjust the branch.