### PR TITLE
feat(llma): Add Claude Code LLM Analytics integration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
-  "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code",
-  "version": "1.0.3",
+  "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
+  "version": "1.1.0",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Official PostHog plugin for AI clients. Access your analytics, feature flags, ex
     ```
     Then follow the browser prompts to log into PostHog.
 
+3. (Optional) Send Claude Code sessions to PostHog LLM Analytics:
+    ```bash
+    export POSTHOG_API_KEY="phc_..."
+    export POSTHOG_HOST="https://eu.i.posthog.com"  # optional, defaults to US
+    ```
+    Sessions are automatically sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. No data is sent unless `POSTHOG_API_KEY` is set.
+
 ### Cursor
 
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add manually in Cursor Settings > Plugins.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ Official PostHog plugin for AI clients. Access your analytics, feature flags, ex
       }
     }
     ```
-    Or via shell profile: `export POSTHOG_LLMA_CC_ENABLED=true POSTHOG_API_KEY="phc_..."`.
 
-    Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content.
+    Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. Add custom properties to all events with `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON string, e.g. `'{"ai_product": "my-app"}'`).
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Official PostHog plugin for AI clients. Access your analytics, feature flags, ex
 
 3. (Optional) Send Claude Code sessions to PostHog LLM Analytics:
     ```bash
+    export POSTHOG_LLMA_CC_ENABLED=true
     export POSTHOG_API_KEY="phc_..."
     export POSTHOG_HOST="https://eu.i.posthog.com"  # optional, defaults to US
     ```
-    Sessions are automatically sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. No data is sent unless `POSTHOG_API_KEY` is set.
+    Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content.
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,20 @@ Official PostHog plugin for AI clients. Access your analytics, feature flags, ex
     ```
     Then follow the browser prompts to log into PostHog.
 
-3. (Optional) Send Claude Code sessions to PostHog LLM Analytics:
-    ```bash
-    export POSTHOG_LLMA_CC_ENABLED=true
-    export POSTHOG_API_KEY="phc_..."
-    export POSTHOG_HOST="https://eu.i.posthog.com"  # optional, defaults to US
+3. (Optional) Send Claude Code sessions to PostHog LLM Analytics.
+
+    Add to `~/.claude/settings.json` (global) or `.claude/settings.local.json` (per-project):
+    ```json
+    {
+      "env": {
+        "POSTHOG_LLMA_CC_ENABLED": "true",
+        "POSTHOG_API_KEY": "phc_...",
+        "POSTHOG_HOST": "https://eu.i.posthog.com"
+      }
+    }
     ```
+    Or via shell profile: `export POSTHOG_LLMA_CC_ENABLED=true POSTHOG_API_KEY="phc_..."`.
+
     Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content.
 
 ### Cursor

--- a/commands/llma-cc-ingest.md
+++ b/commands/llma-cc-ingest.md
@@ -1,0 +1,32 @@
+---
+description: Manually send a Claude Code session log to PostHog LLM Analytics
+argument-hint: [session-id or path]
+allowed-tools: Bash(python3:*),Bash(ls:*),Bash(echo:*)
+---
+
+# LLM Analytics — Ingest Session
+
+Manually send a Claude Code session log to PostHog LLM Analytics.
+
+## Usage
+
+The argument `$ARGUMENTS` can be:
+- A session ID (e.g. `14a1687c-1937-4719-921d-cb2400d7a114`)
+- A path to a JSONL file (e.g. `~/.claude/projects/-Users-me-myproject/14a1687c.jsonl`)
+- Empty — will use the most recent session log for the current project
+
+## Steps
+
+1. Resolve the session log path from the argument
+2. Run the ingest script
+3. Report the results
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/llma_cc_ingest.py $ARGUMENTS
+```
+
+If no argument is provided, list recent sessions and let the user choose:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/llma_cc_ingest.py --list
+```

--- a/commands/llma-cc-setup.md
+++ b/commands/llma-cc-setup.md
@@ -14,7 +14,7 @@ When enabled, every Claude Code session is automatically sent to PostHog's LLM A
 
 ## Configuration
 
-The user needs to set these environment variables (in their shell profile or Claude Code settings):
+Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Set them via environment variables — either in your shell profile or in Claude Code's settings.json `env` block.
 
 ### Required
 
@@ -26,24 +26,18 @@ The user needs to set these environment variables (in their shell profile or Cla
 - `POSTHOG_HOST` — PostHog instance URL (default: `https://us.i.posthog.com`, use `https://eu.i.posthog.com` for EU)
 - `POSTHOG_LLMA_PRIVACY_MODE` — Set to `true` to redact prompt/output content (tokens and costs still captured)
 - `POSTHOG_LLMA_DISTINCT_ID` — Override the distinct_id (default: git user email)
+- `POSTHOG_LLMA_TRACE_GROUPING` — `session` (default) or `message`
 
 ## Steps
 
-1. Check if `POSTHOG_API_KEY` is already set in the environment
+1. Check if the env vars are already set
 2. If the user provided an API key as an argument (`$ARGUMENTS`), guide them to set it
 3. Help them choose US or EU hosting
-4. Suggest adding to their shell profile or `~/.claude/settings.json` env block
-5. Explain that analytics will start flowing on the next session end
+4. Offer them a choice of how to configure
 
-## Example shell profile setup
+## Option 1: Claude Code settings.json (recommended)
 
-```bash
-export POSTHOG_LLMA_CC_ENABLED=true
-export POSTHOG_API_KEY="phc_..."
-export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
-```
-
-## Example Claude Code settings.json setup
+For global setup, add to `~/.claude/settings.json`:
 
 ```json
 {
@@ -55,7 +49,27 @@ export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
 }
 ```
 
-Check current status:
+For per-project setup, add to `.claude/settings.local.json`:
+
+```json
+{
+  "env": {
+    "POSTHOG_LLMA_CC_ENABLED": "true",
+    "POSTHOG_API_KEY": "phc_...",
+    "POSTHOG_HOST": "https://eu.i.posthog.com"
+  }
+}
+```
+
+## Option 2: Shell profile
+
+```bash
+export POSTHOG_LLMA_CC_ENABLED=true
+export POSTHOG_API_KEY="phc_..."
+export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
+```
+
+## Check current status
 
 ```bash
 echo "POSTHOG_LLMA_CC_ENABLED=${POSTHOG_LLMA_CC_ENABLED:-(not set, defaults to false)}"

--- a/commands/llma-cc-setup.md
+++ b/commands/llma-cc-setup.md
@@ -27,6 +27,7 @@ Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Set them
 - `POSTHOG_LLMA_PRIVACY_MODE` — Set to `true` to redact prompt/output content (tokens and costs still captured)
 - `POSTHOG_LLMA_DISTINCT_ID` — Override the distinct_id (default: git user email)
 - `POSTHOG_LLMA_TRACE_GROUPING` — `session` (default) or `message`
+- `POSTHOG_LLMA_CUSTOM_PROPERTIES` — JSON object of custom properties added to all events (e.g. `{"ai_product": "my-app"}`)
 
 ## Steps
 
@@ -61,12 +62,27 @@ For per-project setup, add to `.claude/settings.local.json`:
 }
 ```
 
+### Custom properties
+
+To tag all events with custom properties (e.g. for filtering in PostHog):
+
+```json
+{
+  "env": {
+    "POSTHOG_LLMA_CC_ENABLED": "true",
+    "POSTHOG_API_KEY": "phc_...",
+    "POSTHOG_LLMA_CUSTOM_PROPERTIES": "{\"ai_product\": \"my-app\", \"team\": \"platform\"}"
+  }
+}
+```
+
 ## Option 2: Shell profile
 
 ```bash
 export POSTHOG_LLMA_CC_ENABLED=true
 export POSTHOG_API_KEY="phc_..."
 export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
+export POSTHOG_LLMA_CUSTOM_PROPERTIES='{"ai_product": "my-app"}'  # optional
 ```
 
 ## Check current status
@@ -76,4 +92,5 @@ echo "POSTHOG_LLMA_CC_ENABLED=${POSTHOG_LLMA_CC_ENABLED:-(not set, defaults to f
 echo "POSTHOG_API_KEY=${POSTHOG_API_KEY:-(not set)}"
 echo "POSTHOG_HOST=${POSTHOG_HOST:-(not set, defaults to US)}"
 echo "POSTHOG_LLMA_PRIVACY_MODE=${POSTHOG_LLMA_PRIVACY_MODE:-(not set, defaults to false)}"
+echo "POSTHOG_LLMA_CUSTOM_PROPERTIES=${POSTHOG_LLMA_CUSTOM_PROPERTIES:-(not set)}"
 ```

--- a/commands/llma-cc-setup.md
+++ b/commands/llma-cc-setup.md
@@ -1,0 +1,63 @@
+---
+description: Set up PostHog LLM Analytics to capture Claude Code sessions
+argument-hint: [api-key]
+allowed-tools: Bash(echo:*),Bash(cat:*),Bash(mkdir:*)
+---
+
+# LLM Analytics — Claude Code Setup
+
+Help the user configure PostHog LLM Analytics for Claude Code session capture.
+
+## What this does
+
+When enabled, every Claude Code session is automatically sent to PostHog's LLM Analytics as `$ai_generation`, `$ai_span`, and `$ai_trace` events — giving visibility into model usage, token consumption, tool calls, and costs.
+
+## Configuration
+
+The user needs to set these environment variables (in their shell profile or Claude Code settings):
+
+### Required
+
+- `POSTHOG_API_KEY` — PostHog project API key (starts with `phc_`)
+
+### Optional
+
+- `POSTHOG_HOST` — PostHog instance URL (default: `https://us.i.posthog.com`, use `https://eu.i.posthog.com` for EU)
+- `POSTHOG_LLMA_PRIVACY_MODE` — Set to `true` to redact prompt/output content (tokens and costs still captured)
+- `POSTHOG_LLMA_ENABLED` — Set to `false` to disable without removing the API key
+- `POSTHOG_LLMA_DISTINCT_ID` — Override the distinct_id (default: git user email)
+
+## Steps
+
+1. Check if `POSTHOG_API_KEY` is already set in the environment
+2. If the user provided an API key as an argument (`$ARGUMENTS`), guide them to set it
+3. Help them choose US or EU hosting
+4. Suggest adding to their shell profile or `~/.claude/settings.json` env block
+5. Explain that analytics will start flowing on the next session end
+
+## Example shell profile setup
+
+```bash
+export POSTHOG_API_KEY="phc_..."
+export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
+```
+
+## Example Claude Code settings.json setup
+
+```json
+{
+  "env": {
+    "POSTHOG_API_KEY": "phc_...",
+    "POSTHOG_HOST": "https://eu.i.posthog.com"
+  }
+}
+```
+
+Check current status:
+
+```bash
+echo "POSTHOG_API_KEY=${POSTHOG_API_KEY:-(not set)}"
+echo "POSTHOG_HOST=${POSTHOG_HOST:-(not set, defaults to US)}"
+echo "POSTHOG_LLMA_ENABLED=${POSTHOG_LLMA_ENABLED:-(not set, defaults to true)}"
+echo "POSTHOG_LLMA_PRIVACY_MODE=${POSTHOG_LLMA_PRIVACY_MODE:-(not set, defaults to false)}"
+```

--- a/commands/llma-cc-setup.md
+++ b/commands/llma-cc-setup.md
@@ -18,13 +18,13 @@ The user needs to set these environment variables (in their shell profile or Cla
 
 ### Required
 
+- `POSTHOG_LLMA_CC_ENABLED` — Set to `true` to enable (must be explicitly opted in)
 - `POSTHOG_API_KEY` — PostHog project API key (starts with `phc_`)
 
 ### Optional
 
 - `POSTHOG_HOST` — PostHog instance URL (default: `https://us.i.posthog.com`, use `https://eu.i.posthog.com` for EU)
 - `POSTHOG_LLMA_PRIVACY_MODE` — Set to `true` to redact prompt/output content (tokens and costs still captured)
-- `POSTHOG_LLMA_ENABLED` — Set to `false` to disable without removing the API key
 - `POSTHOG_LLMA_DISTINCT_ID` — Override the distinct_id (default: git user email)
 
 ## Steps
@@ -38,6 +38,7 @@ The user needs to set these environment variables (in their shell profile or Cla
 ## Example shell profile setup
 
 ```bash
+export POSTHOG_LLMA_CC_ENABLED=true
 export POSTHOG_API_KEY="phc_..."
 export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
 ```
@@ -47,6 +48,7 @@ export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
 ```json
 {
   "env": {
+    "POSTHOG_LLMA_CC_ENABLED": "true",
     "POSTHOG_API_KEY": "phc_...",
     "POSTHOG_HOST": "https://eu.i.posthog.com"
   }
@@ -56,8 +58,8 @@ export POSTHOG_HOST="https://eu.i.posthog.com"  # for EU, omit for US
 Check current status:
 
 ```bash
+echo "POSTHOG_LLMA_CC_ENABLED=${POSTHOG_LLMA_CC_ENABLED:-(not set, defaults to false)}"
 echo "POSTHOG_API_KEY=${POSTHOG_API_KEY:-(not set)}"
 echo "POSTHOG_HOST=${POSTHOG_HOST:-(not set, defaults to US)}"
-echo "POSTHOG_LLMA_ENABLED=${POSTHOG_LLMA_ENABLED:-(not set, defaults to true)}"
 echo "POSTHOG_LLMA_PRIVACY_MODE=${POSTHOG_LLMA_PRIVACY_MODE:-(not set, defaults to false)}"
 ```

--- a/commands/llma-cc-status.md
+++ b/commands/llma-cc-status.md
@@ -12,9 +12,9 @@ Check the status of the PostHog LLM Analytics integration for Claude Code.
 1. Check if `POSTHOG_API_KEY` is set:
 
 ```bash
+echo "POSTHOG_LLMA_CC_ENABLED=${POSTHOG_LLMA_CC_ENABLED:-(not set, defaults to false)}"
 echo "POSTHOG_API_KEY=${POSTHOG_API_KEY:-(not set)}"
 echo "POSTHOG_HOST=${POSTHOG_HOST:-(not set, defaults to US)}"
-echo "POSTHOG_LLMA_ENABLED=${POSTHOG_LLMA_ENABLED:-(not set, defaults to true)}"
 echo "POSTHOG_LLMA_PRIVACY_MODE=${POSTHOG_LLMA_PRIVACY_MODE:-(not set, defaults to false)}"
 ```
 

--- a/commands/llma-cc-status.md
+++ b/commands/llma-cc-status.md
@@ -16,6 +16,7 @@ echo "POSTHOG_LLMA_CC_ENABLED=${POSTHOG_LLMA_CC_ENABLED:-(not set, defaults to f
 echo "POSTHOG_API_KEY=${POSTHOG_API_KEY:-(not set)}"
 echo "POSTHOG_HOST=${POSTHOG_HOST:-(not set, defaults to US)}"
 echo "POSTHOG_LLMA_PRIVACY_MODE=${POSTHOG_LLMA_PRIVACY_MODE:-(not set, defaults to false)}"
+echo "POSTHOG_LLMA_CUSTOM_PROPERTIES=${POSTHOG_LLMA_CUSTOM_PROPERTIES:-(not set)}"
 ```
 
 2. Check the last send status:

--- a/commands/llma-cc-status.md
+++ b/commands/llma-cc-status.md
@@ -1,0 +1,30 @@
+---
+description: Check if Claude Code sessions are being sent to PostHog LLM Analytics
+allowed-tools: Bash(echo:*),Bash(cat:*),Bash(python3:*)
+---
+
+# LLM Analytics — Claude Code Status
+
+Check the status of the PostHog LLM Analytics integration for Claude Code.
+
+## Steps
+
+1. Check if `POSTHOG_API_KEY` is set:
+
+```bash
+echo "POSTHOG_API_KEY=${POSTHOG_API_KEY:-(not set)}"
+echo "POSTHOG_HOST=${POSTHOG_HOST:-(not set, defaults to US)}"
+echo "POSTHOG_LLMA_ENABLED=${POSTHOG_LLMA_ENABLED:-(not set, defaults to true)}"
+echo "POSTHOG_LLMA_PRIVACY_MODE=${POSTHOG_LLMA_PRIVACY_MODE:-(not set, defaults to false)}"
+```
+
+2. Check the last send status:
+
+```bash
+cat ~/.claude/posthog-llma-status.json 2>/dev/null || echo "No sessions sent yet"
+```
+
+3. Summarize the results for the user:
+   - If API key is not set: explain they need to run `/posthog:llma-cc-setup`
+   - If API key is set but no status file: explain that data will be sent after the next session ends
+   - If status file exists: show when the last session was sent, how many events, and whether it succeeded

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "PostHog LLM Analytics - sends Claude Code session data to PostHog",
+  "hooks": {
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session-end-llma.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -1,567 +1,38 @@
 #!/usr/bin/env python3
-"""
-Claude Code SessionEnd hook — parses session JSONL and sends
-$ai_generation, $ai_span, $ai_trace events to PostHog LLM Analytics.
+"""Claude Code SessionEnd hook — thin entry point.
 
-No-op if POSTHOG_API_KEY is not set.
-
-This is the Claude Code specific adapter. The generic event building
-and sending logic lives in scripts/posthog_llma.py.
+Parses session JSONL and sends $ai_generation, $ai_span, $ai_trace
+events to PostHog LLM Analytics. No-op unless POSTHOG_LLMA_CC_ENABLED
+is set to true and POSTHOG_API_KEY is set.
 """
 
 import json
 import os
+import subprocess
 import sys
-import uuid
-from pathlib import Path
 
-# Add scripts/ to path so we can import the generic module
-PLUGIN_ROOT = os.environ.get("CLAUDE_PLUGIN_ROOT", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.insert(0, os.path.join(PLUGIN_ROOT, "scripts"))
+# Add plugin root to path so we can import the posthog_llma package
+PLUGIN_ROOT = os.environ.get(
+    "CLAUDE_PLUGIN_ROOT",
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+)
+sys.path.insert(0, PLUGIN_ROOT)
 
-import posthog_llma  # noqa: E402
-
-
-# ---------------------------------------------------------------------------
-# Config
-# ---------------------------------------------------------------------------
-
-def load_config() -> dict:
-    """Load configuration from env vars and optional config file."""
-    config = {
-        "api_key": os.environ.get("POSTHOG_API_KEY", ""),
-        "host": os.environ.get("POSTHOG_HOST", posthog_llma.DEFAULT_HOST),
-        "privacy_mode": os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true",
-        "enabled": os.environ.get("POSTHOG_LLMA_CC_ENABLED", "false").lower() == "true",
-        "distinct_id": os.environ.get("POSTHOG_LLMA_DISTINCT_ID", ""),
-        "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
-        "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),  # "session" or "message"
-    }
-
-    # Try config file as fallback for missing values
-    config_path = os.path.expanduser("~/.claude/posthog-llma.local.md")
-    if os.path.isfile(config_path):
-        try:
-            with open(config_path) as f:
-                content = f.read()
-            # Parse YAML-like frontmatter
-            if content.startswith("---"):
-                end = content.find("---", 3)
-                if end > 0:
-                    for line in content[3:end].strip().splitlines():
-                        if ":" in line:
-                            key, val = line.split(":", 1)
-                            key = key.strip()
-                            val = val.strip().strip('"').strip("'")
-                            if key == "api_key" and not config["api_key"]:
-                                config["api_key"] = val
-                            elif key == "host" and config["host"] == posthog_llma.DEFAULT_HOST:
-                                config["host"] = val
-                            elif key == "distinct_id" and not config["distinct_id"]:
-                                config["distinct_id"] = val
-                            elif key == "privacy_mode" and val.lower() == "true":
-                                config["privacy_mode"] = True
-        except OSError:
-            pass
-
-    return config
-
-
-# ---------------------------------------------------------------------------
-# JSONL parser
-# ---------------------------------------------------------------------------
-
-def find_session_log(session_id: str, cwd: str) -> str | None:
-    """Find the JSONL session log file."""
-    # Claude Code stores logs at ~/.claude/projects/{cwd-as-dashes}/{session_id}.jsonl
-    project_dir_name = cwd.replace("/", "-")
-    path = Path.home() / ".claude" / "projects" / project_dir_name / f"{session_id}.jsonl"
-    if path.is_file():
-        return str(path)
-    return None
-
-
-def parse_session(jsonl_path: str, config: dict) -> dict:
-    """Parse a Claude Code session JSONL file into structured data.
-
-    Returns:
-        {
-            "session_id": str,
-            "generations": [...],  # assistant messages with usage
-            "tool_uses": [...],    # tool calls with results
-            "prompts": [...],      # user prompts (for trace grouping)
-            "metadata": {...},     # session metadata
-        }
-    """
-    generations_by_msg_id = {}  # msg_id -> (generation_dict, [tool_uses])
-    generations_order = []  # preserve insertion order of msg_ids
-    tool_results = {}  # tool_use_id -> result content
-    prompts = []  # {prompt_id, timestamp, text}
-    metadata = {}
-
-    session_id = ""
-    privacy_mode = config["privacy_mode"]
-
-    # Maps for resolving promptId via parentUuid chains.
-    # Assistant messages don't carry promptId directly — it lives on the
-    # originating user message. We walk parentUuid up the chain to find it.
-    uuid_to_prompt_id = {}  # uuid -> promptId (only user prompt entries)
-    uuid_to_parent = {}     # uuid -> parentUuid (all entries)
-
-    # First pass: build UUID maps
-    with open(jsonl_path) as f:
-        for line in f:
-            if not line.strip():
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            uid = entry.get("uuid", "")
-            if uid:
-                parent = entry.get("parentUuid", "")
-                if parent:
-                    uuid_to_parent[uid] = parent
-                prompt_id = entry.get("promptId", "")
-                if prompt_id:
-                    uuid_to_prompt_id[uid] = prompt_id
-
-    def resolve_prompt_id(entry_uuid: str) -> str:
-        """Walk parentUuid chain to find the promptId."""
-        current = entry_uuid
-        for _ in range(30):
-            if current in uuid_to_prompt_id:
-                return uuid_to_prompt_id[current]
-            parent = uuid_to_parent.get(current)
-            if not parent:
-                break
-            current = parent
-        return ""
-
-    # No separate seen_message_ids needed — we use generations_by_msg_id
-    # to deduplicate, keeping the last (most complete) version.
-
-    # Second pass: extract data
-    with open(jsonl_path) as f:
-        for line in f:
-            if not line.strip():
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            entry_type = entry.get("type", "")
-
-            # Session metadata
-            if entry_type == "permission-mode":
-                session_id = entry.get("sessionId", "")
-
-            # User messages (prompts + tool results)
-            if entry_type == "user":
-                msg = entry.get("message", {})
-                if msg.get("role") == "user":
-                    prompt_id = entry.get("promptId", "")
-                    timestamp = entry.get("timestamp", "")
-
-                    # Check if this contains tool results.
-                    # Tool results can appear in two places:
-                    #   1. entry.toolUseResult + entry.sourceToolUseID (older format)
-                    #   2. message.content[] items with type=tool_result and tool_use_id
-                    tool_result_top = entry.get("toolUseResult")
-                    has_tool_result = False
-
-                    if tool_result_top:
-                        source_tool_id = entry.get("sourceToolUseID", "")
-                        if source_tool_id:
-                            tool_results[source_tool_id] = tool_result_top
-                            has_tool_result = True
-
-                    # Also check content array for tool_result items
-                    msg_content = msg.get("content", "")
-                    if isinstance(msg_content, list):
-                        for item in msg_content:
-                            if isinstance(item, dict) and item.get("type") == "tool_result":
-                                tool_use_id = item.get("tool_use_id", "")
-                                if tool_use_id:
-                                    tool_results[tool_use_id] = item
-                                    has_tool_result = True
-
-                    if not has_tool_result and not entry.get("isMeta"):
-                        # It's a user prompt (or slash command invocation)
-                        content = msg_content
-                        if isinstance(content, list):
-                            text_parts = []
-                            for item in content:
-                                if isinstance(item, dict) and item.get("type") == "text":
-                                    text_parts.append(item.get("text", ""))
-                            content = "\n".join(text_parts)
-                        if isinstance(content, str) and content.strip():
-                            # Use promptId if available, otherwise fall back
-                            # to the entry's uuid so slash commands (which
-                            # lack a promptId) still get captured.
-                            effective_prompt_id = prompt_id or entry.get("uuid", str(uuid.uuid4()))
-                            # Store in uuid_to_prompt_id so the parentUuid
-                            # chain can resolve generations back to this prompt
-                            entry_uuid = entry.get("uuid", "")
-                            if entry_uuid and effective_prompt_id:
-                                uuid_to_prompt_id[entry_uuid] = effective_prompt_id
-                            prompts.append({
-                                "prompt_id": effective_prompt_id,
-                                "timestamp": timestamp,
-                                "text": content if not privacy_mode else None,
-                            })
-
-            # Assistant messages (generations)
-            # Session logs can have duplicate entries for the same message
-            # (streaming updates). The later entry is more complete (has
-            # tool_use blocks etc.), so we collect all entries and then
-            # deduplicate by keeping the last occurrence per message ID.
-            if entry_type == "assistant":
-                msg = entry.get("message", {})
-                if msg.get("role") != "assistant":
-                    continue
-
-                msg_id = msg.get("id", "")
-
-                usage = msg.get("usage", {})
-                model = msg.get("model", "unknown")
-                stop_reason = msg.get("stop_reason")
-                timestamp = entry.get("timestamp", "")
-                entry_uuid = entry.get("uuid", "")
-                prompt_id = resolve_prompt_id(entry_uuid)
-                span_id = str(uuid.uuid4())
-
-                # Extract text content, thinking blocks, and tool_use blocks
-                content = msg.get("content", [])
-                text_parts = []
-                entry_tool_uses = []
-
-                if isinstance(content, list):
-                    for item in content:
-                        if isinstance(item, dict):
-                            if item.get("type") == "text":
-                                text_parts.append(item.get("text", ""))
-                            elif item.get("type") == "thinking":
-                                # Include thinking as output so responses
-                                # that only think still show content
-                                thinking_text = item.get("thinking", "")
-                                if thinking_text:
-                                    text_parts.append(thinking_text)
-                            elif item.get("type") == "tool_use":
-                                entry_tool_uses.append({
-                                    "tool_use_id": item.get("id", ""),
-                                    "name": item.get("name", "unknown"),
-                                    "input": item.get("input"),
-                                    "generation_span_id": span_id,
-                                    "prompt_id": prompt_id,
-                                    "timestamp": timestamp,
-                                })
-
-                output_text = "\n".join(text_parts) if text_parts else None
-
-                # Build tool_use content blocks for $ai_output_choices
-                # so PostHog's ingestion can extract $ai_tools_called
-                tool_use_blocks = [
-                    {"type": "tool_use", "name": tu["name"]}
-                    for tu in entry_tool_uses
-                ]
-
-                generation = {
-                    "model": model,
-                    "input_tokens": usage.get("input_tokens", 0),
-                    "output_tokens": usage.get("output_tokens", 0),
-                    "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
-                    "cache_creation_tokens": usage.get("cache_creation_input_tokens", 0),
-                    "stop_reason": stop_reason,
-                    "timestamp": timestamp,
-                    "prompt_id": prompt_id,
-                    "span_id": span_id,
-                    "output_text": output_text,
-                    "tool_use_blocks": tool_use_blocks,
-                    "is_error": stop_reason == "error",
-                    "error_message": msg.get("error_message"),
-                }
-
-                # Overwrite earlier entries for the same msg_id (later
-                # entries are more complete — they include tool_use blocks).
-                key = msg_id or entry_uuid or str(uuid.uuid4())
-                if key not in generations_by_msg_id:
-                    generations_order.append(key)
-                generations_by_msg_id[key] = (generation, entry_tool_uses)
-
-            # Session summary
-            if entry_type == "system" and entry.get("subtype") == "turn_duration":
-                metadata["duration_ms"] = entry.get("durationMs")
-                metadata["message_count"] = entry.get("messageCount")
-                if not session_id:
-                    session_id = entry.get("sessionId", "")
-
-            # Capture metadata from any entry
-            if not metadata.get("version"):
-                metadata["version"] = entry.get("version", "")
-            if not metadata.get("cwd"):
-                metadata["cwd"] = entry.get("cwd", "")
-            if not metadata.get("git_branch"):
-                metadata["git_branch"] = entry.get("gitBranch", "")
-
-    # Flatten deduplicated generations and tool uses
-    generations = []
-    tool_uses = []
-    for key in generations_order:
-        gen, tus = generations_by_msg_id[key]
-        generations.append(gen)
-        tool_uses.extend(tus)
-
-    # Attach tool results to tool uses
-    for tu in tool_uses:
-        result = tool_results.get(tu["tool_use_id"])
-        if result:
-            tu["result"] = result
-
-    return {
-        "session_id": session_id,
-        "generations": generations,
-        "tool_uses": tool_uses,
-        "prompts": prompts,
-        "metadata": metadata,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Build PostHog events from parsed session
-# ---------------------------------------------------------------------------
-
-import re as _re
-
-# Prompts that are framework noise — skip when picking a trace name
-_SKIP_PROMPTS = _re.compile(
-    r"^(/clear|/exit|/quit|/help|/compact|/reload|clear|exit|quit|"
-    r"\[Request interrupted|\[Request cancelled)",
-    _re.IGNORECASE,
+from posthog_llma import (  # noqa: E402
+    load_config,
+    find_session_log,
+    parse_session,
+    build_events,
+    send_batch,
+    write_status,
 )
 
 
-def _clean_trace_name(text: str, max_len: int = 100) -> str:
-    """Strip XML/HTML tags and truncate for use as a trace name."""
-    cleaned = _re.sub(r"<[^>]+>", "", text).strip()
-    # Collapse whitespace
-    cleaned = " ".join(cleaned.split())
-    return cleaned[:max_len] if cleaned else text[:max_len]
-
-
-def _find_trace_name(prompts: list[dict], max_len: int = 100) -> str | None:
-    """Find the first meaningful user prompt to use as a trace name."""
-    for p in prompts:
-        text = p.get("text", "")
-        if not text:
-            continue
-        cleaned = _clean_trace_name(text, max_len)
-        if cleaned and not _SKIP_PROMPTS.match(cleaned):
-            return cleaned
-    # Fallback: use whatever the first prompt is, even if noisy
-    if prompts and prompts[0].get("text"):
-        return _clean_trace_name(prompts[0]["text"], max_len)
-    return None
-
-
-def build_events(parsed: dict, config: dict) -> list[dict]:
-    """Convert parsed session data into PostHog $ai_* events.
-
-    Supports two trace grouping modes (POSTHOG_LLMA_TRACE_GROUPING):
-      - "session" (default): one $ai_trace per session, all generations
-        and spans grouped under it
-      - "message": one $ai_trace per user prompt
-    """
-    events = []
-    session_id = parsed["session_id"]
-    cwd = parsed["metadata"].get("cwd", "")
-    project_name = os.path.basename(cwd) if cwd else ""
-    privacy_mode = config["privacy_mode"]
-    trace_grouping = config.get("trace_grouping", "session")
-
-    # In session mode, all events share one trace_id (the session_id).
-    # In message mode, each prompt gets its own trace_id (the promptId).
-    session_trace_id = session_id
-
-    all_generations = parsed["generations"]
-    all_tool_uses = parsed["tool_uses"]
-
-    # Build $ai_generation events
-    for gen in all_generations:
-        trace_id = session_trace_id if trace_grouping == "session" else (gen.get("prompt_id") or str(uuid.uuid4()))
-
-        output_choices = None
-        if not privacy_mode:
-            # Build output in Anthropic format so PostHog can extract
-            # $ai_tools_called from content[].type="tool_use" blocks
-            content_blocks = []
-            if gen["output_text"]:
-                content_blocks.append({"type": "text", "text": gen["output_text"]})
-            content_blocks.extend(gen.get("tool_use_blocks", []))
-            if content_blocks:
-                output_choices = [{"role": "assistant", "content": content_blocks}]
-
-        # Find the user prompt for this generation
-        user_prompt = None
-        input_messages = None
-        for p in parsed["prompts"]:
-            if p["prompt_id"] == gen.get("prompt_id"):
-                user_prompt = p.get("text")
-                if user_prompt and not privacy_mode:
-                    input_messages = [{"role": "user", "content": user_prompt}]
-                break
-
-        events.append(posthog_llma.build_ai_generation(
-            model=gen["model"],
-            provider="anthropic",
-            input_tokens=gen["input_tokens"],
-            output_tokens=gen["output_tokens"],
-            cache_read_tokens=gen["cache_read_tokens"],
-            cache_creation_tokens=gen["cache_creation_tokens"],
-            stop_reason=gen["stop_reason"],
-            is_error=gen["is_error"],
-            error_message=gen.get("error_message"),
-            trace_id=trace_id,
-            span_id=gen["span_id"],
-            session_id=session_id,
-            input_messages=input_messages,
-            output_choices=output_choices,
-            user_prompt=user_prompt,
-            project_name=project_name,
-            privacy_mode=privacy_mode,
-            timestamp=gen.get("timestamp"),
-        ))
-
-    # Build $ai_span events for tool uses
-    for tu in all_tool_uses:
-        trace_id = session_trace_id if trace_grouping == "session" else (tu.get("prompt_id") or str(uuid.uuid4()))
-
-        result = tu.get("result")
-        is_error = False
-        error_message = None
-        output_state = None
-
-        if result:
-            if isinstance(result, dict):
-                is_error = result.get("is_error", False) or result.get("isError", False)
-                output_state = result.get("content", result)
-                if is_error:
-                    error_message = str(result.get("error", result.get("content", "")))[:500]
-            else:
-                output_state = result
-
-        events.append(posthog_llma.build_ai_span(
-            span_name=tu["name"],
-            trace_id=trace_id,
-            parent_span_id=tu.get("generation_span_id"),
-            session_id=session_id,
-            input_state=tu.get("input") if not privacy_mode else None,
-            output_state=output_state if not privacy_mode else None,
-            is_error=is_error,
-            error_message=error_message,
-            project_name=project_name,
-            privacy_mode=privacy_mode,
-            max_attribute_length=config["max_attribute_length"],
-            timestamp=tu.get("timestamp"),
-        ))
-
-    # Build $ai_trace events
-    if trace_grouping == "session":
-        # One trace for the whole session
-        total_input = sum(g["input_tokens"] for g in all_generations)
-        total_output = sum(g["output_tokens"] for g in all_generations)
-        has_error = any(g["is_error"] for g in all_generations)
-        error_msg = next((g["error_message"] for g in all_generations if g.get("error_message")), None)
-
-        # Session latency from first to last generation
-        timestamps = [g["timestamp"] for g in all_generations if g.get("timestamp")]
-        latency = None
-        if len(timestamps) >= 2:
-            try:
-                from datetime import datetime as dt
-                first = dt.fromisoformat(timestamps[0].replace("Z", "+00:00"))
-                last = dt.fromisoformat(timestamps[-1].replace("Z", "+00:00"))
-                latency = (last - first).total_seconds()
-            except (ValueError, TypeError):
-                pass
-
-        # Use first generation timestamp for the trace
-        trace_ts = timestamps[0] if timestamps else None
-
-        # Use first meaningful user prompt as the trace name
-        trace_name = _find_trace_name(parsed["prompts"])
-
-        events.append(posthog_llma.build_ai_trace(
-            trace_id=session_trace_id,
-            session_id=session_id,
-            trace_name=trace_name,
-            latency_seconds=latency,
-            total_input_tokens=total_input,
-            total_output_tokens=total_output,
-            is_error=has_error,
-            error_message=error_msg,
-            project_name=project_name,
-            timestamp=trace_ts,
-        ))
-    else:
-        # One trace per user prompt
-        prompt_generations = {}
-        for gen in all_generations:
-            pid = gen.get("prompt_id", "")
-            if pid:
-                prompt_generations.setdefault(pid, []).append(gen)
-
-        for prompt in parsed["prompts"]:
-            pid = prompt["prompt_id"]
-            gens = prompt_generations.get(pid, [])
-
-            total_input = sum(g["input_tokens"] for g in gens)
-            total_output = sum(g["output_tokens"] for g in gens)
-            has_error = any(g["is_error"] for g in gens)
-            error_msg = next((g["error_message"] for g in gens if g.get("error_message")), None)
-
-            timestamps = [g["timestamp"] for g in gens if g.get("timestamp")]
-            latency = None
-            if len(timestamps) >= 2:
-                try:
-                    from datetime import datetime as dt
-                    first = dt.fromisoformat(timestamps[0].replace("Z", "+00:00"))
-                    last = dt.fromisoformat(timestamps[-1].replace("Z", "+00:00"))
-                    latency = (last - first).total_seconds()
-                except (ValueError, TypeError):
-                    pass
-
-            prompt_ts = timestamps[0] if timestamps else prompt.get("timestamp")
-            trace_name = _find_trace_name([prompt])
-
-            events.append(posthog_llma.build_ai_trace(
-                trace_id=pid,
-                session_id=session_id,
-                trace_name=trace_name,
-                latency_seconds=latency,
-                total_input_tokens=total_input,
-                total_output_tokens=total_output,
-                is_error=has_error,
-                error_message=error_msg,
-                project_name=project_name,
-                timestamp=prompt_ts,
-            ))
-
-    return events
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
 def main():
-    # Load config — exit immediately if not configured
     config = load_config()
     if not config["enabled"] or not config["api_key"]:
         sys.exit(0)
 
-    # Read hook input from stdin
     try:
         hook_input = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -569,11 +40,9 @@ def main():
 
     session_id = hook_input.get("session_id", "")
     cwd = hook_input.get("cwd", "")
-
     if not session_id or not cwd:
         sys.exit(0)
 
-    # Find and parse session log
     jsonl_path = find_session_log(session_id, cwd)
     if not jsonl_path:
         sys.exit(0)
@@ -582,7 +51,6 @@ def main():
     if not parsed["generations"]:
         sys.exit(0)
 
-    # Build events
     events = build_events(parsed, config)
     if not events:
         sys.exit(0)
@@ -590,9 +58,7 @@ def main():
     # Determine distinct_id
     distinct_id = config["distinct_id"]
     if not distinct_id:
-        # Try git user email
         try:
-            import subprocess
             result = subprocess.run(
                 ["git", "config", "user.email"],
                 capture_output=True, text=True, timeout=2, cwd=cwd,
@@ -604,16 +70,14 @@ def main():
     if not distinct_id:
         distinct_id = f"claude-code:{session_id}"
 
-    # Send to PostHog
-    result = posthog_llma.send_batch(
+    result = send_batch(
         events,
         api_key=config["api_key"],
         host=config["host"],
         distinct_id=distinct_id,
     )
 
-    # Write status for /posthog:llma-status
-    posthog_llma.write_status({
+    write_status({
         "session_id": session_id,
         "events_sent": result.get("sent", 0),
         "generations": len(parsed["generations"]),
@@ -626,7 +90,6 @@ def main():
         "project_name": os.path.basename(cwd) if cwd else "",
     })
 
-    # Exit 0 regardless — don't disrupt the session end
     sys.exit(0)
 
 

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -32,7 +32,7 @@ def load_config() -> dict:
         "api_key": os.environ.get("POSTHOG_API_KEY", ""),
         "host": os.environ.get("POSTHOG_HOST", posthog_llma.DEFAULT_HOST),
         "privacy_mode": os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true",
-        "enabled": os.environ.get("POSTHOG_LLMA_ENABLED", "true").lower() != "false",
+        "enabled": os.environ.get("POSTHOG_LLMA_CC_ENABLED", "false").lower() == "true",
         "distinct_id": os.environ.get("POSTHOG_LLMA_DISTINCT_ID", ""),
         "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
         "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),  # "session" or "message"

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -260,6 +260,13 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
 
                 output_text = "\n".join(text_parts) if text_parts else None
 
+                # Build tool_use content blocks for $ai_output_choices
+                # so PostHog's ingestion can extract $ai_tools_called
+                tool_use_blocks = [
+                    {"type": "tool_use", "name": tu["name"]}
+                    for tu in entry_tool_uses
+                ]
+
                 generation = {
                     "model": model,
                     "input_tokens": usage.get("input_tokens", 0),
@@ -271,6 +278,7 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
                     "prompt_id": prompt_id,
                     "span_id": span_id,
                     "output_text": output_text,
+                    "tool_use_blocks": tool_use_blocks,
                     "is_error": stop_reason == "error",
                     "error_message": msg.get("error_message"),
                 }
@@ -384,8 +392,15 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
         trace_id = session_trace_id if trace_grouping == "session" else (gen.get("prompt_id") or str(uuid.uuid4()))
 
         output_choices = None
-        if gen["output_text"] and not privacy_mode:
-            output_choices = [{"role": "assistant", "content": gen["output_text"]}]
+        if not privacy_mode:
+            # Build output in Anthropic format so PostHog can extract
+            # $ai_tools_called from content[].type="tool_use" blocks
+            content_blocks = []
+            if gen["output_text"]:
+                content_blocks.append({"type": "text", "text": gen["output_text"]})
+            content_blocks.extend(gen.get("tool_use_blocks", []))
+            if content_blocks:
+                output_choices = [{"role": "assistant", "content": content_blocks}]
 
         # Find the user prompt for this generation
         user_prompt = None

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -29,6 +29,15 @@ from posthog_llma import (  # noqa: E402
 
 
 def main():
+    try:
+        _run()
+    except Exception:
+        # Never crash — losing a session send is fine, interfering
+        # with the user's workflow is not.
+        sys.exit(0)
+
+
+def _run():
     config = load_config()
     if not config["enabled"] or not config["api_key"]:
         sys.exit(0)

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -326,12 +326,35 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
 
 import re as _re
 
+# Prompts that are framework noise — skip when picking a trace name
+_SKIP_PROMPTS = _re.compile(
+    r"^(/clear|/exit|/quit|/help|/compact|/reload|clear|exit|quit|"
+    r"\[Request interrupted|\[Request cancelled)",
+    _re.IGNORECASE,
+)
+
+
 def _clean_trace_name(text: str, max_len: int = 100) -> str:
     """Strip XML/HTML tags and truncate for use as a trace name."""
     cleaned = _re.sub(r"<[^>]+>", "", text).strip()
     # Collapse whitespace
     cleaned = " ".join(cleaned.split())
     return cleaned[:max_len] if cleaned else text[:max_len]
+
+
+def _find_trace_name(prompts: list[dict], max_len: int = 100) -> str | None:
+    """Find the first meaningful user prompt to use as a trace name."""
+    for p in prompts:
+        text = p.get("text", "")
+        if not text:
+            continue
+        cleaned = _clean_trace_name(text, max_len)
+        if cleaned and not _SKIP_PROMPTS.match(cleaned):
+            return cleaned
+    # Fallback: use whatever the first prompt is, even if noisy
+    if prompts and prompts[0].get("text"):
+        return _clean_trace_name(prompts[0]["text"], max_len)
+    return None
 
 
 def build_events(parsed: dict, config: dict) -> list[dict]:
@@ -451,9 +474,8 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
         # Use first generation timestamp for the trace
         trace_ts = timestamps[0] if timestamps else None
 
-        # Use first user prompt as the trace name (truncated, tags stripped)
-        first_prompt = parsed["prompts"][0].get("text", "") if parsed["prompts"] else ""
-        trace_name = _clean_trace_name(first_prompt) if first_prompt else None
+        # Use first meaningful user prompt as the trace name
+        trace_name = _find_trace_name(parsed["prompts"])
 
         events.append(posthog_llma.build_ai_trace(
             trace_id=session_trace_id,
@@ -496,8 +518,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
                     pass
 
             prompt_ts = timestamps[0] if timestamps else prompt.get("timestamp")
-            prompt_text = prompt.get("text", "")
-            trace_name = _clean_trace_name(prompt_text) if prompt_text else None
+            trace_name = _find_trace_name([prompt])
 
             events.append(posthog_llma.build_ai_trace(
                 trace_id=pid,

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""
+Claude Code SessionEnd hook — parses session JSONL and sends
+$ai_generation, $ai_span, $ai_trace events to PostHog LLM Analytics.
+
+No-op if POSTHOG_API_KEY is not set.
+
+This is the Claude Code specific adapter. The generic event building
+and sending logic lives in scripts/posthog_llma.py.
+"""
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+# Add scripts/ to path so we can import the generic module
+PLUGIN_ROOT = os.environ.get("CLAUDE_PLUGIN_ROOT", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(PLUGIN_ROOT, "scripts"))
+
+import posthog_llma  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def load_config() -> dict:
+    """Load configuration from env vars and optional config file."""
+    config = {
+        "api_key": os.environ.get("POSTHOG_API_KEY", ""),
+        "host": os.environ.get("POSTHOG_HOST", posthog_llma.DEFAULT_HOST),
+        "privacy_mode": os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true",
+        "enabled": os.environ.get("POSTHOG_LLMA_ENABLED", "true").lower() != "false",
+        "distinct_id": os.environ.get("POSTHOG_LLMA_DISTINCT_ID", ""),
+        "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
+        "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),  # "session" or "message"
+    }
+
+    # Try config file as fallback for missing values
+    config_path = os.path.expanduser("~/.claude/posthog-llma.local.md")
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path) as f:
+                content = f.read()
+            # Parse YAML-like frontmatter
+            if content.startswith("---"):
+                end = content.find("---", 3)
+                if end > 0:
+                    for line in content[3:end].strip().splitlines():
+                        if ":" in line:
+                            key, val = line.split(":", 1)
+                            key = key.strip()
+                            val = val.strip().strip('"').strip("'")
+                            if key == "api_key" and not config["api_key"]:
+                                config["api_key"] = val
+                            elif key == "host" and config["host"] == posthog_llma.DEFAULT_HOST:
+                                config["host"] = val
+                            elif key == "distinct_id" and not config["distinct_id"]:
+                                config["distinct_id"] = val
+                            elif key == "privacy_mode" and val.lower() == "true":
+                                config["privacy_mode"] = True
+        except OSError:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# JSONL parser
+# ---------------------------------------------------------------------------
+
+def find_session_log(session_id: str, cwd: str) -> str | None:
+    """Find the JSONL session log file."""
+    # Claude Code stores logs at ~/.claude/projects/{cwd-as-dashes}/{session_id}.jsonl
+    project_dir_name = cwd.replace("/", "-")
+    path = Path.home() / ".claude" / "projects" / project_dir_name / f"{session_id}.jsonl"
+    if path.is_file():
+        return str(path)
+    return None
+
+
+def parse_session(jsonl_path: str, config: dict) -> dict:
+    """Parse a Claude Code session JSONL file into structured data.
+
+    Returns:
+        {
+            "session_id": str,
+            "generations": [...],  # assistant messages with usage
+            "tool_uses": [...],    # tool calls with results
+            "prompts": [...],      # user prompts (for trace grouping)
+            "metadata": {...},     # session metadata
+        }
+    """
+    generations_by_msg_id = {}  # msg_id -> (generation_dict, [tool_uses])
+    generations_order = []  # preserve insertion order of msg_ids
+    tool_results = {}  # tool_use_id -> result content
+    prompts = []  # {prompt_id, timestamp, text}
+    metadata = {}
+
+    session_id = ""
+    privacy_mode = config["privacy_mode"]
+
+    # Maps for resolving promptId via parentUuid chains.
+    # Assistant messages don't carry promptId directly — it lives on the
+    # originating user message. We walk parentUuid up the chain to find it.
+    uuid_to_prompt_id = {}  # uuid -> promptId (only user prompt entries)
+    uuid_to_parent = {}     # uuid -> parentUuid (all entries)
+
+    # First pass: build UUID maps
+    with open(jsonl_path) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            uid = entry.get("uuid", "")
+            if uid:
+                parent = entry.get("parentUuid", "")
+                if parent:
+                    uuid_to_parent[uid] = parent
+                prompt_id = entry.get("promptId", "")
+                if prompt_id:
+                    uuid_to_prompt_id[uid] = prompt_id
+
+    def resolve_prompt_id(entry_uuid: str) -> str:
+        """Walk parentUuid chain to find the promptId."""
+        current = entry_uuid
+        for _ in range(30):
+            if current in uuid_to_prompt_id:
+                return uuid_to_prompt_id[current]
+            parent = uuid_to_parent.get(current)
+            if not parent:
+                break
+            current = parent
+        return ""
+
+    # No separate seen_message_ids needed — we use generations_by_msg_id
+    # to deduplicate, keeping the last (most complete) version.
+
+    # Second pass: extract data
+    with open(jsonl_path) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            entry_type = entry.get("type", "")
+
+            # Session metadata
+            if entry_type == "permission-mode":
+                session_id = entry.get("sessionId", "")
+
+            # User messages (prompts + tool results)
+            if entry_type == "user":
+                msg = entry.get("message", {})
+                if msg.get("role") == "user":
+                    prompt_id = entry.get("promptId", "")
+                    timestamp = entry.get("timestamp", "")
+
+                    # Check if this contains tool results.
+                    # Tool results can appear in two places:
+                    #   1. entry.toolUseResult + entry.sourceToolUseID (older format)
+                    #   2. message.content[] items with type=tool_result and tool_use_id
+                    tool_result_top = entry.get("toolUseResult")
+                    has_tool_result = False
+
+                    if tool_result_top:
+                        source_tool_id = entry.get("sourceToolUseID", "")
+                        if source_tool_id:
+                            tool_results[source_tool_id] = tool_result_top
+                            has_tool_result = True
+
+                    # Also check content array for tool_result items
+                    msg_content = msg.get("content", "")
+                    if isinstance(msg_content, list):
+                        for item in msg_content:
+                            if isinstance(item, dict) and item.get("type") == "tool_result":
+                                tool_use_id = item.get("tool_use_id", "")
+                                if tool_use_id:
+                                    tool_results[tool_use_id] = item
+                                    has_tool_result = True
+
+                    if not has_tool_result:
+                        # It's a user prompt
+                        content = msg_content
+                        if isinstance(content, list):
+                            text_parts = []
+                            for item in content:
+                                if isinstance(item, dict) and item.get("type") == "text":
+                                    text_parts.append(item.get("text", ""))
+                            content = "\n".join(text_parts)
+                        if prompt_id and isinstance(content, str) and not entry.get("isMeta"):
+                            prompts.append({
+                                "prompt_id": prompt_id,
+                                "timestamp": timestamp,
+                                "text": content if not privacy_mode else None,
+                            })
+
+            # Assistant messages (generations)
+            # Session logs can have duplicate entries for the same message
+            # (streaming updates). The later entry is more complete (has
+            # tool_use blocks etc.), so we collect all entries and then
+            # deduplicate by keeping the last occurrence per message ID.
+            if entry_type == "assistant":
+                msg = entry.get("message", {})
+                if msg.get("role") != "assistant":
+                    continue
+
+                msg_id = msg.get("id", "")
+
+                usage = msg.get("usage", {})
+                model = msg.get("model", "unknown")
+                stop_reason = msg.get("stop_reason")
+                timestamp = entry.get("timestamp", "")
+                entry_uuid = entry.get("uuid", "")
+                prompt_id = resolve_prompt_id(entry_uuid)
+                span_id = str(uuid.uuid4())
+
+                # Extract text content, thinking blocks, and tool_use blocks
+                content = msg.get("content", [])
+                text_parts = []
+                entry_tool_uses = []
+
+                if isinstance(content, list):
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                text_parts.append(item.get("text", ""))
+                            elif item.get("type") == "thinking":
+                                # Include thinking as output so responses
+                                # that only think still show content
+                                thinking_text = item.get("thinking", "")
+                                if thinking_text:
+                                    text_parts.append(thinking_text)
+                            elif item.get("type") == "tool_use":
+                                entry_tool_uses.append({
+                                    "tool_use_id": item.get("id", ""),
+                                    "name": item.get("name", "unknown"),
+                                    "input": item.get("input"),
+                                    "generation_span_id": span_id,
+                                    "prompt_id": prompt_id,
+                                    "timestamp": timestamp,
+                                })
+
+                output_text = "\n".join(text_parts) if text_parts else None
+
+                generation = {
+                    "model": model,
+                    "input_tokens": usage.get("input_tokens", 0),
+                    "output_tokens": usage.get("output_tokens", 0),
+                    "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
+                    "cache_creation_tokens": usage.get("cache_creation_input_tokens", 0),
+                    "stop_reason": stop_reason,
+                    "timestamp": timestamp,
+                    "prompt_id": prompt_id,
+                    "span_id": span_id,
+                    "output_text": output_text,
+                    "is_error": stop_reason == "error",
+                    "error_message": msg.get("error_message"),
+                }
+
+                # Overwrite earlier entries for the same msg_id (later
+                # entries are more complete — they include tool_use blocks).
+                key = msg_id or entry_uuid or str(uuid.uuid4())
+                if key not in generations_by_msg_id:
+                    generations_order.append(key)
+                generations_by_msg_id[key] = (generation, entry_tool_uses)
+
+            # Session summary
+            if entry_type == "system" and entry.get("subtype") == "turn_duration":
+                metadata["duration_ms"] = entry.get("durationMs")
+                metadata["message_count"] = entry.get("messageCount")
+                if not session_id:
+                    session_id = entry.get("sessionId", "")
+
+            # Capture metadata from any entry
+            if not metadata.get("version"):
+                metadata["version"] = entry.get("version", "")
+            if not metadata.get("cwd"):
+                metadata["cwd"] = entry.get("cwd", "")
+            if not metadata.get("git_branch"):
+                metadata["git_branch"] = entry.get("gitBranch", "")
+
+    # Flatten deduplicated generations and tool uses
+    generations = []
+    tool_uses = []
+    for key in generations_order:
+        gen, tus = generations_by_msg_id[key]
+        generations.append(gen)
+        tool_uses.extend(tus)
+
+    # Attach tool results to tool uses
+    for tu in tool_uses:
+        result = tool_results.get(tu["tool_use_id"])
+        if result:
+            tu["result"] = result
+
+    return {
+        "session_id": session_id,
+        "generations": generations,
+        "tool_uses": tool_uses,
+        "prompts": prompts,
+        "metadata": metadata,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Build PostHog events from parsed session
+# ---------------------------------------------------------------------------
+
+def build_events(parsed: dict, config: dict) -> list[dict]:
+    """Convert parsed session data into PostHog $ai_* events.
+
+    Supports two trace grouping modes (POSTHOG_LLMA_TRACE_GROUPING):
+      - "session" (default): one $ai_trace per session, all generations
+        and spans grouped under it
+      - "message": one $ai_trace per user prompt
+    """
+    events = []
+    session_id = parsed["session_id"]
+    cwd = parsed["metadata"].get("cwd", "")
+    project_name = os.path.basename(cwd) if cwd else ""
+    privacy_mode = config["privacy_mode"]
+    trace_grouping = config.get("trace_grouping", "session")
+
+    # In session mode, all events share one trace_id (the session_id).
+    # In message mode, each prompt gets its own trace_id (the promptId).
+    session_trace_id = session_id
+
+    all_generations = parsed["generations"]
+    all_tool_uses = parsed["tool_uses"]
+
+    # Build $ai_generation events
+    for gen in all_generations:
+        trace_id = session_trace_id if trace_grouping == "session" else (gen.get("prompt_id") or str(uuid.uuid4()))
+
+        output_choices = None
+        if gen["output_text"] and not privacy_mode:
+            output_choices = [{"role": "assistant", "content": gen["output_text"]}]
+
+        # Find the user prompt for this generation
+        user_prompt = None
+        input_messages = None
+        for p in parsed["prompts"]:
+            if p["prompt_id"] == gen.get("prompt_id"):
+                user_prompt = p.get("text")
+                if user_prompt and not privacy_mode:
+                    input_messages = [{"role": "user", "content": user_prompt}]
+                break
+
+        events.append(posthog_llma.build_ai_generation(
+            model=gen["model"],
+            provider="anthropic",
+            input_tokens=gen["input_tokens"],
+            output_tokens=gen["output_tokens"],
+            cache_read_tokens=gen["cache_read_tokens"],
+            cache_creation_tokens=gen["cache_creation_tokens"],
+            stop_reason=gen["stop_reason"],
+            is_error=gen["is_error"],
+            error_message=gen.get("error_message"),
+            trace_id=trace_id,
+            span_id=gen["span_id"],
+            session_id=session_id,
+            input_messages=input_messages,
+            output_choices=output_choices,
+            user_prompt=user_prompt,
+            project_name=project_name,
+            privacy_mode=privacy_mode,
+            timestamp=gen.get("timestamp"),
+        ))
+
+    # Build $ai_span events for tool uses
+    for tu in all_tool_uses:
+        trace_id = session_trace_id if trace_grouping == "session" else (tu.get("prompt_id") or str(uuid.uuid4()))
+
+        result = tu.get("result")
+        is_error = False
+        error_message = None
+        output_state = None
+
+        if result:
+            if isinstance(result, dict):
+                is_error = result.get("is_error", False) or result.get("isError", False)
+                output_state = result.get("content", result)
+                if is_error:
+                    error_message = str(result.get("error", result.get("content", "")))[:500]
+            else:
+                output_state = result
+
+        events.append(posthog_llma.build_ai_span(
+            span_name=tu["name"],
+            trace_id=trace_id,
+            parent_span_id=tu.get("generation_span_id"),
+            session_id=session_id,
+            input_state=tu.get("input") if not privacy_mode else None,
+            output_state=output_state if not privacy_mode else None,
+            is_error=is_error,
+            error_message=error_message,
+            project_name=project_name,
+            privacy_mode=privacy_mode,
+            max_attribute_length=config["max_attribute_length"],
+            timestamp=tu.get("timestamp"),
+        ))
+
+    # Build $ai_trace events
+    if trace_grouping == "session":
+        # One trace for the whole session
+        total_input = sum(g["input_tokens"] for g in all_generations)
+        total_output = sum(g["output_tokens"] for g in all_generations)
+        has_error = any(g["is_error"] for g in all_generations)
+        error_msg = next((g["error_message"] for g in all_generations if g.get("error_message")), None)
+
+        # Session latency from first to last generation
+        timestamps = [g["timestamp"] for g in all_generations if g.get("timestamp")]
+        latency = None
+        if len(timestamps) >= 2:
+            try:
+                from datetime import datetime as dt
+                first = dt.fromisoformat(timestamps[0].replace("Z", "+00:00"))
+                last = dt.fromisoformat(timestamps[-1].replace("Z", "+00:00"))
+                latency = (last - first).total_seconds()
+            except (ValueError, TypeError):
+                pass
+
+        # Use first generation timestamp for the trace
+        trace_ts = timestamps[0] if timestamps else None
+
+        # Use first user prompt as the trace name (truncated)
+        first_prompt = parsed["prompts"][0].get("text", "") if parsed["prompts"] else ""
+        trace_name = first_prompt[:100] if first_prompt else None
+
+        events.append(posthog_llma.build_ai_trace(
+            trace_id=session_trace_id,
+            session_id=session_id,
+            trace_name=trace_name,
+            latency_seconds=latency,
+            total_input_tokens=total_input,
+            total_output_tokens=total_output,
+            is_error=has_error,
+            error_message=error_msg,
+            project_name=project_name,
+            timestamp=trace_ts,
+        ))
+    else:
+        # One trace per user prompt
+        prompt_generations = {}
+        for gen in all_generations:
+            pid = gen.get("prompt_id", "")
+            if pid:
+                prompt_generations.setdefault(pid, []).append(gen)
+
+        for prompt in parsed["prompts"]:
+            pid = prompt["prompt_id"]
+            gens = prompt_generations.get(pid, [])
+
+            total_input = sum(g["input_tokens"] for g in gens)
+            total_output = sum(g["output_tokens"] for g in gens)
+            has_error = any(g["is_error"] for g in gens)
+            error_msg = next((g["error_message"] for g in gens if g.get("error_message")), None)
+
+            timestamps = [g["timestamp"] for g in gens if g.get("timestamp")]
+            latency = None
+            if len(timestamps) >= 2:
+                try:
+                    from datetime import datetime as dt
+                    first = dt.fromisoformat(timestamps[0].replace("Z", "+00:00"))
+                    last = dt.fromisoformat(timestamps[-1].replace("Z", "+00:00"))
+                    latency = (last - first).total_seconds()
+                except (ValueError, TypeError):
+                    pass
+
+            prompt_ts = timestamps[0] if timestamps else prompt.get("timestamp")
+            prompt_text = prompt.get("text", "")
+            trace_name = prompt_text[:100] if prompt_text else None
+
+            events.append(posthog_llma.build_ai_trace(
+                trace_id=pid,
+                session_id=session_id,
+                trace_name=trace_name,
+                latency_seconds=latency,
+                total_input_tokens=total_input,
+                total_output_tokens=total_output,
+                is_error=has_error,
+                error_message=error_msg,
+                project_name=project_name,
+                timestamp=prompt_ts,
+            ))
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    # Load config — exit immediately if not configured
+    config = load_config()
+    if not config["enabled"] or not config["api_key"]:
+        sys.exit(0)
+
+    # Read hook input from stdin
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    session_id = hook_input.get("session_id", "")
+    cwd = hook_input.get("cwd", "")
+
+    if not session_id or not cwd:
+        sys.exit(0)
+
+    # Find and parse session log
+    jsonl_path = find_session_log(session_id, cwd)
+    if not jsonl_path:
+        sys.exit(0)
+
+    parsed = parse_session(jsonl_path, config)
+    if not parsed["generations"]:
+        sys.exit(0)
+
+    # Build events
+    events = build_events(parsed, config)
+    if not events:
+        sys.exit(0)
+
+    # Determine distinct_id
+    distinct_id = config["distinct_id"]
+    if not distinct_id:
+        # Try git user email
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["git", "config", "user.email"],
+                capture_output=True, text=True, timeout=2, cwd=cwd,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                distinct_id = result.stdout.strip()
+        except Exception:
+            pass
+    if not distinct_id:
+        distinct_id = f"claude-code:{session_id}"
+
+    # Send to PostHog
+    result = posthog_llma.send_batch(
+        events,
+        api_key=config["api_key"],
+        host=config["host"],
+        distinct_id=distinct_id,
+    )
+
+    # Write status for /posthog:llma-status
+    posthog_llma.write_status({
+        "session_id": session_id,
+        "events_sent": result.get("sent", 0),
+        "generations": len(parsed["generations"]),
+        "tool_uses": len(parsed["tool_uses"]),
+        "traces": len(parsed["prompts"]),
+        "status": result.get("status", "unknown"),
+        "error": result.get("error"),
+        "host": config["host"],
+        "distinct_id": distinct_id,
+        "project_name": os.path.basename(cwd) if cwd else "",
+    })
+
+    # Exit 0 regardless — don't disrupt the session end
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/session-end-llma.py
+++ b/hooks/session-end-llma.py
@@ -187,8 +187,8 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
                                     tool_results[tool_use_id] = item
                                     has_tool_result = True
 
-                    if not has_tool_result:
-                        # It's a user prompt
+                    if not has_tool_result and not entry.get("isMeta"):
+                        # It's a user prompt (or slash command invocation)
                         content = msg_content
                         if isinstance(content, list):
                             text_parts = []
@@ -196,9 +196,18 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
                                 if isinstance(item, dict) and item.get("type") == "text":
                                     text_parts.append(item.get("text", ""))
                             content = "\n".join(text_parts)
-                        if prompt_id and isinstance(content, str) and not entry.get("isMeta"):
+                        if isinstance(content, str) and content.strip():
+                            # Use promptId if available, otherwise fall back
+                            # to the entry's uuid so slash commands (which
+                            # lack a promptId) still get captured.
+                            effective_prompt_id = prompt_id or entry.get("uuid", str(uuid.uuid4()))
+                            # Store in uuid_to_prompt_id so the parentUuid
+                            # chain can resolve generations back to this prompt
+                            entry_uuid = entry.get("uuid", "")
+                            if entry_uuid and effective_prompt_id:
+                                uuid_to_prompt_id[entry_uuid] = effective_prompt_id
                             prompts.append({
-                                "prompt_id": prompt_id,
+                                "prompt_id": effective_prompt_id,
                                 "timestamp": timestamp,
                                 "text": content if not privacy_mode else None,
                             })
@@ -314,6 +323,16 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
 # ---------------------------------------------------------------------------
 # Build PostHog events from parsed session
 # ---------------------------------------------------------------------------
+
+import re as _re
+
+def _clean_trace_name(text: str, max_len: int = 100) -> str:
+    """Strip XML/HTML tags and truncate for use as a trace name."""
+    cleaned = _re.sub(r"<[^>]+>", "", text).strip()
+    # Collapse whitespace
+    cleaned = " ".join(cleaned.split())
+    return cleaned[:max_len] if cleaned else text[:max_len]
+
 
 def build_events(parsed: dict, config: dict) -> list[dict]:
     """Convert parsed session data into PostHog $ai_* events.
@@ -432,9 +451,9 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
         # Use first generation timestamp for the trace
         trace_ts = timestamps[0] if timestamps else None
 
-        # Use first user prompt as the trace name (truncated)
+        # Use first user prompt as the trace name (truncated, tags stripped)
         first_prompt = parsed["prompts"][0].get("text", "") if parsed["prompts"] else ""
-        trace_name = first_prompt[:100] if first_prompt else None
+        trace_name = _clean_trace_name(first_prompt) if first_prompt else None
 
         events.append(posthog_llma.build_ai_trace(
             trace_id=session_trace_id,
@@ -478,7 +497,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
 
             prompt_ts = timestamps[0] if timestamps else prompt.get("timestamp")
             prompt_text = prompt.get("text", "")
-            trace_name = prompt_text[:100] if prompt_text else None
+            trace_name = _clean_trace_name(prompt_text) if prompt_text else None
 
             events.append(posthog_llma.build_ai_trace(
                 trace_id=pid,

--- a/posthog_llma/__init__.py
+++ b/posthog_llma/__init__.py
@@ -1,0 +1,30 @@
+"""PostHog LLM Analytics — zero-dependency Python package.
+
+Builds $ai_generation, $ai_span, and $ai_trace events and sends them
+to PostHog. Client-specific adapters (e.g. Claude Code) live in the
+hooks/ and scripts/ directories.
+"""
+
+from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
+from posthog_llma.sender import DEFAULT_HOST, send_batch, write_status, read_status, STATUS_FILE
+from posthog_llma.config import load_config
+from posthog_llma.parser import parse_session, find_session_log
+from posthog_llma.trace_naming import find_trace_name, clean_trace_name
+from posthog_llma.event_builder import build_events
+
+__all__ = [
+    "build_ai_generation",
+    "build_ai_span",
+    "build_ai_trace",
+    "send_batch",
+    "write_status",
+    "read_status",
+    "STATUS_FILE",
+    "DEFAULT_HOST",
+    "load_config",
+    "parse_session",
+    "find_session_log",
+    "find_trace_name",
+    "clean_trace_name",
+    "build_events",
+]

--- a/posthog_llma/config.py
+++ b/posthog_llma/config.py
@@ -1,0 +1,50 @@
+"""Configuration loading from env vars and optional config file."""
+
+import os
+
+from posthog_llma.sender import DEFAULT_HOST
+
+
+def load_config() -> dict:
+    """Load configuration from env vars and optional config file.
+
+    Env vars always take precedence. The config file at
+    ~/.claude/posthog-llma.local.md is used as a fallback.
+    """
+    config = {
+        "api_key": os.environ.get("POSTHOG_API_KEY", ""),
+        "host": os.environ.get("POSTHOG_HOST", DEFAULT_HOST),
+        "privacy_mode": os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true",
+        "enabled": os.environ.get("POSTHOG_LLMA_CC_ENABLED", "false").lower() == "true",
+        "distinct_id": os.environ.get("POSTHOG_LLMA_DISTINCT_ID", ""),
+        "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
+        "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),
+    }
+
+    # Try config file as fallback for missing values
+    config_path = os.path.expanduser("~/.claude/posthog-llma.local.md")
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path) as f:
+                content = f.read()
+            # Parse YAML-like frontmatter
+            if content.startswith("---"):
+                end = content.find("---", 3)
+                if end > 0:
+                    for line in content[3:end].strip().splitlines():
+                        if ":" in line:
+                            key, val = line.split(":", 1)
+                            key = key.strip()
+                            val = val.strip().strip('"').strip("'")
+                            if key == "api_key" and not config["api_key"]:
+                                config["api_key"] = val
+                            elif key == "host" and config["host"] == DEFAULT_HOST:
+                                config["host"] = val
+                            elif key == "distinct_id" and not config["distinct_id"]:
+                                config["distinct_id"] = val
+                            elif key == "privacy_mode" and val.lower() == "true":
+                                config["privacy_mode"] = True
+        except OSError:
+            pass
+
+    return config

--- a/posthog_llma/config.py
+++ b/posthog_llma/config.py
@@ -21,6 +21,13 @@ import os
 from posthog_llma.sender import DEFAULT_HOST
 
 
+def _safe_int(val: str, default: int) -> int:
+    try:
+        return int(val) if val else default
+    except (ValueError, TypeError):
+        return default
+
+
 def load_config() -> dict:
     """Load configuration from environment variables.
 
@@ -43,7 +50,7 @@ def load_config() -> dict:
         "privacy_mode": os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true",
         "enabled": os.environ.get("POSTHOG_LLMA_CC_ENABLED", "false").lower() == "true",
         "distinct_id": os.environ.get("POSTHOG_LLMA_DISTINCT_ID", ""),
-        "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
+        "max_attribute_length": _safe_int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", ""), 12000),
         "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),
         "custom_properties": custom_props,
     }

--- a/posthog_llma/config.py
+++ b/posthog_llma/config.py
@@ -1,4 +1,18 @@
-"""Configuration loading from env vars and optional config file."""
+"""Configuration loading from environment variables.
+
+All configuration is via env vars. Users can set these in their shell
+profile or in Claude Code's settings.json "env" block:
+
+    // ~/.claude/settings.json (global)
+    // .claude/settings.local.json (per-project, gitignored)
+    {
+      "env": {
+        "POSTHOG_LLMA_CC_ENABLED": "true",
+        "POSTHOG_API_KEY": "phc_...",
+        "POSTHOG_HOST": "https://eu.i.posthog.com"
+      }
+    }
+"""
 
 import os
 
@@ -6,12 +20,12 @@ from posthog_llma.sender import DEFAULT_HOST
 
 
 def load_config() -> dict:
-    """Load configuration from env vars and optional config file.
+    """Load configuration from environment variables.
 
-    Env vars always take precedence. The config file at
-    ~/.claude/posthog-llma.local.md is used as a fallback.
+    Both POSTHOG_LLMA_CC_ENABLED=true and POSTHOG_API_KEY are required
+    for the hook to send data. All other settings have sensible defaults.
     """
-    config = {
+    return {
         "api_key": os.environ.get("POSTHOG_API_KEY", ""),
         "host": os.environ.get("POSTHOG_HOST", DEFAULT_HOST),
         "privacy_mode": os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true",
@@ -20,31 +34,3 @@ def load_config() -> dict:
         "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
         "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),
     }
-
-    # Try config file as fallback for missing values
-    config_path = os.path.expanduser("~/.claude/posthog-llma.local.md")
-    if os.path.isfile(config_path):
-        try:
-            with open(config_path) as f:
-                content = f.read()
-            # Parse YAML-like frontmatter
-            if content.startswith("---"):
-                end = content.find("---", 3)
-                if end > 0:
-                    for line in content[3:end].strip().splitlines():
-                        if ":" in line:
-                            key, val = line.split(":", 1)
-                            key = key.strip()
-                            val = val.strip().strip('"').strip("'")
-                            if key == "api_key" and not config["api_key"]:
-                                config["api_key"] = val
-                            elif key == "host" and config["host"] == DEFAULT_HOST:
-                                config["host"] = val
-                            elif key == "distinct_id" and not config["distinct_id"]:
-                                config["distinct_id"] = val
-                            elif key == "privacy_mode" and val.lower() == "true":
-                                config["privacy_mode"] = True
-        except OSError:
-            pass
-
-    return config

--- a/posthog_llma/config.py
+++ b/posthog_llma/config.py
@@ -9,11 +9,13 @@ profile or in Claude Code's settings.json "env" block:
       "env": {
         "POSTHOG_LLMA_CC_ENABLED": "true",
         "POSTHOG_API_KEY": "phc_...",
-        "POSTHOG_HOST": "https://eu.i.posthog.com"
+        "POSTHOG_HOST": "https://eu.i.posthog.com",
+        "POSTHOG_LLMA_CUSTOM_PROPERTIES": "{\"ai_product\": \"my-app\"}"
       }
     }
 """
 
+import json
 import os
 
 from posthog_llma.sender import DEFAULT_HOST
@@ -25,6 +27,16 @@ def load_config() -> dict:
     Both POSTHOG_LLMA_CC_ENABLED=true and POSTHOG_API_KEY are required
     for the hook to send data. All other settings have sensible defaults.
     """
+    custom_props = {}
+    raw = os.environ.get("POSTHOG_LLMA_CUSTOM_PROPERTIES", "")
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                custom_props = parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+
     return {
         "api_key": os.environ.get("POSTHOG_API_KEY", ""),
         "host": os.environ.get("POSTHOG_HOST", DEFAULT_HOST),
@@ -33,4 +45,5 @@ def load_config() -> dict:
         "distinct_id": os.environ.get("POSTHOG_LLMA_DISTINCT_ID", ""),
         "max_attribute_length": int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000")),
         "trace_grouping": os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session"),
+        "custom_properties": custom_props,
     }

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -26,9 +26,24 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
     all_generations = parsed["generations"]
     all_tool_uses = parsed["tool_uses"]
 
+    # In message mode, if prompt_id is missing we need a stable fallback
+    # so a generation and its tool spans share the same trace_id.
+    # Use span_id as the fallback — it's unique per generation but stable
+    # across the generation and its child tool uses.
+    fallback_trace_ids = {}  # span_id -> fallback trace_id
+
     # -- $ai_generation events --
     for gen in all_generations:
-        trace_id = session_trace_id if trace_grouping == "session" else (gen.get("prompt_id") or str(uuid.uuid4()))
+        if trace_grouping == "session":
+            trace_id = session_trace_id
+        else:
+            prompt_id = gen.get("prompt_id")
+            if prompt_id:
+                trace_id = prompt_id
+            else:
+                # Use span_id as deterministic fallback
+                trace_id = gen["span_id"]
+                fallback_trace_ids[gen["span_id"]] = trace_id
 
         output_choices = None
         if not privacy_mode:
@@ -71,7 +86,15 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
 
     # -- $ai_span events --
     for tu in all_tool_uses:
-        trace_id = session_trace_id if trace_grouping == "session" else (tu.get("prompt_id") or str(uuid.uuid4()))
+        if trace_grouping == "session":
+            trace_id = session_trace_id
+        else:
+            prompt_id = tu.get("prompt_id")
+            if prompt_id:
+                trace_id = prompt_id
+            else:
+                # Use the same fallback as the parent generation
+                trace_id = fallback_trace_ids.get(tu.get("generation_span_id"), tu.get("generation_span_id", str(uuid.uuid4())))
 
         result = tu.get("result")
         is_error = False

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -1,5 +1,6 @@
 """Build PostHog events from parsed Claude Code session data."""
 
+import json
 import os
 import uuid
 from datetime import datetime as dt
@@ -7,6 +8,25 @@ from typing import Optional
 
 from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
 from posthog_llma.trace_naming import find_trace_name
+
+
+def _truncate_tool_blocks(blocks: list, max_len: int) -> list:
+    """Truncate tool use input args to prevent oversized payloads."""
+    result = []
+    for block in blocks:
+        try:
+            if block.get("type") != "tool_use" or "input" not in block:
+                result.append(block)
+                continue
+            inp = block["input"]
+            serialized = json.dumps(inp) if not isinstance(inp, str) else inp
+            if len(serialized) <= max_len:
+                result.append(block)
+            else:
+                result.append({**block, "input": serialized[:max_len]})
+        except Exception:
+            result.append({"type": "tool_use", "name": block.get("name", "unknown")})
+    return result
 
 
 def build_events(parsed: dict, config: dict) -> list[dict]:
@@ -49,10 +69,11 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
 
         output_choices = None
         if not privacy_mode:
+            max_attr = config.get("max_attribute_length", 12000)
             content_blocks = []
             if gen["output_text"]:
                 content_blocks.append({"type": "text", "text": gen["output_text"]})
-            content_blocks.extend(gen.get("tool_use_blocks", []))
+            content_blocks.extend(_truncate_tool_blocks(gen.get("tool_use_blocks", []), max_attr))
             if content_blocks:
                 output_choices = [{"role": "assistant", "content": content_blocks}]
 

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -3,6 +3,7 @@
 import os
 import uuid
 from datetime import datetime as dt
+from typing import Optional
 
 from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
 from posthog_llma.trace_naming import find_trace_name
@@ -74,6 +75,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             is_error=gen["is_error"],
             error_message=gen.get("error_message"),
             trace_id=trace_id,
+            parent_id=trace_id,
             span_id=gen["span_id"],
             session_id=session_id,
             input_messages=input_messages,
@@ -129,12 +131,12 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
     if trace_grouping == "session":
         _build_session_trace(events, parsed, all_generations, session_trace_id, session_id, project_name)
     else:
-        _build_message_traces(events, parsed, all_generations, session_id, project_name)
+        _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids)
 
     return events
 
 
-def _compute_latency(timestamps: list[str]) -> float | None:
+def _compute_latency(timestamps: list[str]) -> Optional[float]:
     """Calculate latency in seconds between first and last timestamp."""
     if len(timestamps) < 2:
         return None
@@ -170,7 +172,7 @@ def _build_session_trace(events, parsed, all_generations, trace_id, session_id, 
     ))
 
 
-def _build_message_traces(events, parsed, all_generations, session_id, project_name):
+def _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids=None):
     prompt_generations = {}
     for gen in all_generations:
         pid = gen.get("prompt_id", "")
@@ -202,3 +204,31 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
             project_name=project_name,
             timestamp=prompt_ts,
         ))
+
+    # Emit root trace events for fallback (unresolved prompt) trace IDs
+    if fallback_trace_ids:
+        fallback_generations = {}
+        for gen in all_generations:
+            tid = fallback_trace_ids.get(gen["span_id"])
+            if tid:
+                fallback_generations.setdefault(tid, []).append(gen)
+
+        for trace_id, gens in fallback_generations.items():
+            total_input = sum(g["input_tokens"] for g in gens)
+            total_output = sum(g["output_tokens"] for g in gens)
+            has_error = any(g["is_error"] for g in gens)
+            error_msg = next((g["error_message"] for g in gens if g.get("error_message")), None)
+            timestamps = [g["timestamp"] for g in gens if g.get("timestamp")]
+
+            events.append(build_ai_trace(
+                trace_id=trace_id,
+                session_id=session_id,
+                trace_name="(unresolved prompt)",
+                latency_seconds=_compute_latency(timestamps),
+                total_input_tokens=total_input,
+                total_output_tokens=total_output,
+                is_error=has_error,
+                error_message=error_msg,
+                project_name=project_name,
+                timestamp=timestamps[0] if timestamps else None,
+            ))

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -1,0 +1,181 @@
+"""Build PostHog events from parsed Claude Code session data."""
+
+import os
+import uuid
+from datetime import datetime as dt
+
+from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
+from posthog_llma.trace_naming import find_trace_name
+
+
+def build_events(parsed: dict, config: dict) -> list[dict]:
+    """Convert parsed session data into PostHog $ai_* events.
+
+    Supports two trace grouping modes (POSTHOG_LLMA_TRACE_GROUPING):
+      - "session" (default): one $ai_trace per session
+      - "message": one $ai_trace per user prompt
+    """
+    events = []
+    session_id = parsed["session_id"]
+    cwd = parsed["metadata"].get("cwd", "")
+    project_name = os.path.basename(cwd) if cwd else ""
+    privacy_mode = config.get("privacy_mode", False)
+    trace_grouping = config.get("trace_grouping", "session")
+
+    session_trace_id = session_id
+    all_generations = parsed["generations"]
+    all_tool_uses = parsed["tool_uses"]
+
+    # -- $ai_generation events --
+    for gen in all_generations:
+        trace_id = session_trace_id if trace_grouping == "session" else (gen.get("prompt_id") or str(uuid.uuid4()))
+
+        output_choices = None
+        if not privacy_mode:
+            content_blocks = []
+            if gen["output_text"]:
+                content_blocks.append({"type": "text", "text": gen["output_text"]})
+            content_blocks.extend(gen.get("tool_use_blocks", []))
+            if content_blocks:
+                output_choices = [{"role": "assistant", "content": content_blocks}]
+
+        user_prompt = None
+        input_messages = None
+        for p in parsed["prompts"]:
+            if p["prompt_id"] == gen.get("prompt_id"):
+                user_prompt = p.get("text")
+                if user_prompt and not privacy_mode:
+                    input_messages = [{"role": "user", "content": user_prompt}]
+                break
+
+        events.append(build_ai_generation(
+            model=gen["model"],
+            provider="anthropic",
+            input_tokens=gen["input_tokens"],
+            output_tokens=gen["output_tokens"],
+            cache_read_tokens=gen["cache_read_tokens"],
+            cache_creation_tokens=gen["cache_creation_tokens"],
+            stop_reason=gen["stop_reason"],
+            is_error=gen["is_error"],
+            error_message=gen.get("error_message"),
+            trace_id=trace_id,
+            span_id=gen["span_id"],
+            session_id=session_id,
+            input_messages=input_messages,
+            output_choices=output_choices,
+            user_prompt=user_prompt,
+            project_name=project_name,
+            privacy_mode=privacy_mode,
+            timestamp=gen.get("timestamp"),
+        ))
+
+    # -- $ai_span events --
+    for tu in all_tool_uses:
+        trace_id = session_trace_id if trace_grouping == "session" else (tu.get("prompt_id") or str(uuid.uuid4()))
+
+        result = tu.get("result")
+        is_error = False
+        error_message = None
+        output_state = None
+
+        if result:
+            if isinstance(result, dict):
+                is_error = result.get("is_error", False) or result.get("isError", False)
+                output_state = result.get("content", result)
+                if is_error:
+                    error_message = str(result.get("error", result.get("content", "")))[:500]
+            else:
+                output_state = result
+
+        events.append(build_ai_span(
+            span_name=tu["name"],
+            trace_id=trace_id,
+            parent_span_id=tu.get("generation_span_id"),
+            session_id=session_id,
+            input_state=tu.get("input") if not privacy_mode else None,
+            output_state=output_state if not privacy_mode else None,
+            is_error=is_error,
+            error_message=error_message,
+            project_name=project_name,
+            privacy_mode=privacy_mode,
+            max_attribute_length=config.get("max_attribute_length", 12000),
+            timestamp=tu.get("timestamp"),
+        ))
+
+    # -- $ai_trace events --
+    if trace_grouping == "session":
+        _build_session_trace(events, parsed, all_generations, session_trace_id, session_id, project_name)
+    else:
+        _build_message_traces(events, parsed, all_generations, session_id, project_name)
+
+    return events
+
+
+def _compute_latency(timestamps: list[str]) -> float | None:
+    """Calculate latency in seconds between first and last timestamp."""
+    if len(timestamps) < 2:
+        return None
+    try:
+        first = dt.fromisoformat(timestamps[0].replace("Z", "+00:00"))
+        last = dt.fromisoformat(timestamps[-1].replace("Z", "+00:00"))
+        return (last - first).total_seconds()
+    except (ValueError, TypeError):
+        return None
+
+
+def _build_session_trace(events, parsed, all_generations, trace_id, session_id, project_name):
+    total_input = sum(g["input_tokens"] for g in all_generations)
+    total_output = sum(g["output_tokens"] for g in all_generations)
+    has_error = any(g["is_error"] for g in all_generations)
+    error_msg = next((g["error_message"] for g in all_generations if g.get("error_message")), None)
+
+    timestamps = [g["timestamp"] for g in all_generations if g.get("timestamp")]
+    trace_ts = timestamps[0] if timestamps else None
+    trace_name = find_trace_name(parsed["prompts"])
+
+    events.append(build_ai_trace(
+        trace_id=trace_id,
+        session_id=session_id,
+        trace_name=trace_name,
+        latency_seconds=_compute_latency(timestamps),
+        total_input_tokens=total_input,
+        total_output_tokens=total_output,
+        is_error=has_error,
+        error_message=error_msg,
+        project_name=project_name,
+        timestamp=trace_ts,
+    ))
+
+
+def _build_message_traces(events, parsed, all_generations, session_id, project_name):
+    prompt_generations = {}
+    for gen in all_generations:
+        pid = gen.get("prompt_id", "")
+        if pid:
+            prompt_generations.setdefault(pid, []).append(gen)
+
+    for prompt in parsed["prompts"]:
+        pid = prompt["prompt_id"]
+        gens = prompt_generations.get(pid, [])
+
+        total_input = sum(g["input_tokens"] for g in gens)
+        total_output = sum(g["output_tokens"] for g in gens)
+        has_error = any(g["is_error"] for g in gens)
+        error_msg = next((g["error_message"] for g in gens if g.get("error_message")), None)
+
+        timestamps = [g["timestamp"] for g in gens if g.get("timestamp")]
+        prompt_ts = timestamps[0] if timestamps else prompt.get("timestamp")
+        trace_name = find_trace_name([prompt])
+
+        events.append(build_ai_trace(
+            trace_id=pid,
+            session_id=session_id,
+            trace_name=trace_name,
+            latency_seconds=_compute_latency(timestamps),
+            total_input_tokens=total_input,
+            total_output_tokens=total_output,
+            is_error=has_error,
+            error_message=error_msg,
+            project_name=project_name,
+            timestamp=prompt_ts,
+        ))

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -12,7 +12,7 @@ from posthog_llma.trace_naming import find_trace_name
 def build_events(parsed: dict, config: dict) -> list[dict]:
     """Convert parsed session data into PostHog $ai_* events.
 
-    Supports two trace grouping modes (POSTHOG_LLMA_TRACE_GROUPING):
+    Supports two trace grouping modes (trace_grouping config):
       - "session" (default): one $ai_trace per session
       - "message": one $ai_trace per user prompt
     """
@@ -22,6 +22,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
     project_name = os.path.basename(cwd) if cwd else ""
     privacy_mode = config.get("privacy_mode", False)
     trace_grouping = config.get("trace_grouping", "session")
+    custom_properties = config.get("custom_properties") or None
 
     session_trace_id = session_id
     all_generations = parsed["generations"]
@@ -83,6 +84,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             user_prompt=user_prompt,
             project_name=project_name,
             privacy_mode=privacy_mode,
+            extra_properties=custom_properties,
             timestamp=gen.get("timestamp"),
         ))
 
@@ -124,14 +126,15 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             project_name=project_name,
             privacy_mode=privacy_mode,
             max_attribute_length=config.get("max_attribute_length", 12000),
+            extra_properties=custom_properties,
             timestamp=tu.get("timestamp"),
         ))
 
     # -- $ai_trace events --
     if trace_grouping == "session":
-        _build_session_trace(events, parsed, all_generations, session_trace_id, session_id, project_name)
+        _build_session_trace(events, parsed, all_generations, session_trace_id, session_id, project_name, custom_properties)
     else:
-        _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids)
+        _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids, custom_properties)
 
     return events
 
@@ -148,7 +151,7 @@ def _compute_latency(timestamps: list[str]) -> Optional[float]:
         return None
 
 
-def _build_session_trace(events, parsed, all_generations, trace_id, session_id, project_name):
+def _build_session_trace(events, parsed, all_generations, trace_id, session_id, project_name, custom_properties=None):
     total_input = sum(g["input_tokens"] for g in all_generations)
     total_output = sum(g["output_tokens"] for g in all_generations)
     has_error = any(g["is_error"] for g in all_generations)
@@ -168,11 +171,12 @@ def _build_session_trace(events, parsed, all_generations, trace_id, session_id, 
         is_error=has_error,
         error_message=error_msg,
         project_name=project_name,
+        extra_properties=custom_properties,
         timestamp=trace_ts,
     ))
 
 
-def _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids=None):
+def _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids=None, custom_properties=None):
     prompt_generations = {}
     for gen in all_generations:
         pid = gen.get("prompt_id", "")
@@ -202,6 +206,7 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
             is_error=has_error,
             error_message=error_msg,
             project_name=project_name,
+            extra_properties=custom_properties,
             timestamp=prompt_ts,
         ))
 
@@ -230,5 +235,6 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
                 is_error=has_error,
                 error_message=error_msg,
                 project_name=project_name,
+                extra_properties=custom_properties,
                 timestamp=timestamps[0] if timestamps else None,
             ))

--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -94,6 +94,7 @@ def build_ai_span(
     agent_name: str = "",
     privacy_mode: bool = False,
     max_attribute_length: int = 12000,
+    extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
 ) -> dict:
     """Build a $ai_span event for a tool execution."""
@@ -120,6 +121,9 @@ def build_ai_span(
         "$ai_agent_name": agent_name,
     }
 
+    if extra_properties:
+        properties.update(extra_properties)
+
     result = {"event": "$ai_span", "properties": properties}
     if timestamp:
         result["timestamp"] = timestamp
@@ -138,6 +142,7 @@ def build_ai_trace(
     error_message: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
+    extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
 ) -> dict:
     """Build a $ai_trace event for a complete prompt-to-response cycle."""
@@ -155,6 +160,9 @@ def build_ai_trace(
         "$ai_project_name": project_name,
         "$ai_agent_name": agent_name,
     }
+
+    if extra_properties:
+        properties.update(extra_properties)
 
     result = {"event": "$ai_trace", "properties": properties}
     if timestamp:

--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -7,6 +7,7 @@ We do NOT need to calculate or send cost — just send model and tokens.
 
 import json
 import uuid
+from typing import Optional
 
 
 def build_ai_generation(
@@ -17,21 +18,22 @@ def build_ai_generation(
     output_tokens: int = 0,
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
-    latency_seconds: float | None = None,
-    stop_reason: str | None = None,
+    latency_seconds: Optional[float] = None,
+    stop_reason: Optional[str] = None,
     is_error: bool = False,
-    error_message: str | None = None,
+    error_message: Optional[str] = None,
     trace_id: str,
-    span_id: str | None = None,
+    parent_id: Optional[str] = None,
+    span_id: Optional[str] = None,
     session_id: str,
     input_messages: object = None,
     output_choices: object = None,
-    user_prompt: str | None = None,
+    user_prompt: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
     privacy_mode: bool = False,
-    extra_properties: dict | None = None,
-    timestamp: str | None = None,
+    extra_properties: Optional[dict] = None,
+    timestamp: Optional[str] = None,
 ) -> dict:
     """Build a $ai_generation event."""
     total_tokens = input_tokens + output_tokens
@@ -51,6 +53,7 @@ def build_ai_generation(
         "$ai_is_error": is_error,
         "$ai_error": error_message,
         "$ai_trace_id": trace_id,
+        "$ai_parent_id": parent_id,
         "$ai_span_id": span_id or str(uuid.uuid4()),
         "$ai_session_id": session_id,
         "$ai_input": None if privacy_mode else input_messages,
@@ -79,19 +82,19 @@ def build_ai_span(
     *,
     span_name: str,
     trace_id: str,
-    parent_span_id: str | None = None,
-    span_id: str | None = None,
+    parent_span_id: Optional[str] = None,
+    span_id: Optional[str] = None,
     session_id: str,
-    latency_seconds: float | None = None,
+    latency_seconds: Optional[float] = None,
     input_state: object = None,
     output_state: object = None,
     is_error: bool = False,
-    error_message: str | None = None,
+    error_message: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
     privacy_mode: bool = False,
     max_attribute_length: int = 12000,
-    timestamp: str | None = None,
+    timestamp: Optional[str] = None,
 ) -> dict:
     """Build a $ai_span event for a tool execution."""
     def _truncate(val, max_len):
@@ -127,15 +130,15 @@ def build_ai_trace(
     *,
     trace_id: str,
     session_id: str,
-    trace_name: str | None = None,
-    latency_seconds: float | None = None,
+    trace_name: Optional[str] = None,
+    latency_seconds: Optional[float] = None,
     total_input_tokens: int = 0,
     total_output_tokens: int = 0,
     is_error: bool = False,
-    error_message: str | None = None,
+    error_message: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
-    timestamp: str | None = None,
+    timestamp: Optional[str] = None,
 ) -> dict:
     """Build a $ai_trace event for a complete prompt-to-response cycle."""
     properties = {

--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -1,31 +1,13 @@
-"""
-PostHog LLM Analytics - Generic event builder and sender.
+"""PostHog $ai_* event builders.
 
-Builds $ai_generation, $ai_span, and $ai_trace events in PostHog's
-LLM analytics format and sends them via the /batch capture endpoint.
-
-This module is client-agnostic — it takes structured data and produces
-PostHog events. Client-specific parsers (e.g. session-end-llma.py for
-Claude Code) feed data into this module.
-
-Zero dependencies — uses only Python stdlib.
+Cost calculation ($ai_total_cost_usd etc.) is handled by PostHog's
+ingestion pipeline automatically from $ai_model + token counts.
+We do NOT need to calculate or send cost — just send model and tokens.
 """
 
 import json
-import os
-import urllib.request
-import urllib.error
 import uuid
-from datetime import datetime, timezone
 
-
-# ---------------------------------------------------------------------------
-# Event builders
-#
-# Note: cost calculation ($ai_total_cost_usd etc.) is handled by PostHog's
-# ingestion pipeline automatically from $ai_model + token counts. We do NOT
-# need to calculate or send cost — just send model and tokens.
-# ---------------------------------------------------------------------------
 
 def build_ai_generation(
     *,
@@ -51,11 +33,7 @@ def build_ai_generation(
     extra_properties: dict | None = None,
     timestamp: str | None = None,
 ) -> dict:
-    """Build a $ai_generation event.
-
-    Cost ($ai_total_cost_usd etc.) is calculated by PostHog's ingestion
-    pipeline from $ai_model + token counts — we don't send it.
-    """
+    """Build a $ai_generation event."""
     total_tokens = input_tokens + output_tokens
 
     # Map Claude Code stop reasons to PostHog's expected values
@@ -159,7 +137,7 @@ def build_ai_trace(
     agent_name: str = "",
     timestamp: str | None = None,
 ) -> dict:
-    """Build a $ai_trace event for a complete prompt→response cycle."""
+    """Build a $ai_trace event for a complete prompt-to-response cycle."""
     properties = {
         "$ai_trace_id": trace_id,
         "$ai_trace_name": trace_name,
@@ -179,97 +157,3 @@ def build_ai_trace(
     if timestamp:
         result["timestamp"] = timestamp
     return result
-
-
-# ---------------------------------------------------------------------------
-# Sender
-# ---------------------------------------------------------------------------
-
-DEFAULT_HOST = "https://us.i.posthog.com"
-
-
-def send_batch(
-    events: list[dict],
-    *,
-    api_key: str,
-    host: str = DEFAULT_HOST,
-    distinct_id: str,
-) -> dict:
-    """Send a batch of events to PostHog's /batch endpoint.
-
-    Each event dict must have 'event' and 'properties' keys.
-    Returns {"status": "ok", "sent": N} on success or {"status": "error", "error": str}.
-    """
-    if not events:
-        return {"status": "ok", "sent": 0}
-
-    batch = []
-    fallback_ts = datetime.now(timezone.utc).isoformat()
-
-    for ev in events:
-        batch.append({
-            "event": ev["event"],
-            "properties": {
-                **ev["properties"],
-                "$lib": "posthog-ai-plugin",
-            },
-            "distinct_id": distinct_id,
-            "timestamp": ev.get("timestamp") or fallback_ts,
-        })
-
-    payload = json.dumps({
-        "api_key": api_key,
-        "batch": batch,
-    }).encode("utf-8")
-
-    url = f"{host.rstrip('/')}/batch"
-
-    req = urllib.request.Request(
-        url,
-        data=payload,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "posthog-ai-plugin/1.0",
-        },
-        method="POST",
-    )
-
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return {"status": "ok", "sent": len(batch), "response_code": resp.status}
-    except urllib.error.HTTPError as e:
-        body = ""
-        try:
-            body = e.read().decode("utf-8", errors="replace")[:500]
-        except Exception:
-            pass
-        return {"status": "error", "error": f"HTTP {e.code}: {body}"}
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
-
-
-# ---------------------------------------------------------------------------
-# Status file helpers
-# ---------------------------------------------------------------------------
-
-STATUS_FILE = os.path.expanduser("~/.claude/posthog-llma-status.json")
-
-
-def write_status(status: dict) -> None:
-    """Write last send status to a file for /posthog:llma-status to read."""
-    status["timestamp"] = datetime.now(timezone.utc).isoformat()
-    try:
-        os.makedirs(os.path.dirname(STATUS_FILE), exist_ok=True)
-        with open(STATUS_FILE, "w") as f:
-            json.dump(status, f, indent=2)
-    except OSError:
-        pass
-
-
-def read_status() -> dict | None:
-    """Read last send status."""
-    try:
-        with open(STATUS_FILE) as f:
-            return json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return None

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -263,7 +263,7 @@ def _process_assistant_entry(
     output_text = "\n".join(text_parts) if text_parts else None
 
     tool_use_blocks = [
-        {"type": "tool_use", "name": tu["name"]}
+        {"type": "tool_use", "name": tu["name"], "input": tu.get("input")}
         for tu in entry_tool_uses
     ]
 

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -1,0 +1,288 @@
+"""Claude Code session JSONL parser.
+
+Reads a Claude Code session log and extracts generations, tool uses,
+prompts, and metadata into a structured dict.
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+
+def find_session_log(session_id: str, cwd: str) -> str | None:
+    """Find the JSONL session log file.
+
+    Claude Code stores logs at:
+        ~/.claude/projects/{cwd-with-slashes-replaced}/{session_id}.jsonl
+    """
+    project_dir_name = cwd.replace("/", "-")
+    path = Path.home() / ".claude" / "projects" / project_dir_name / f"{session_id}.jsonl"
+    if path.is_file():
+        return str(path)
+    return None
+
+
+def parse_session(jsonl_path: str, config: dict) -> dict:
+    """Parse a Claude Code session JSONL file into structured data.
+
+    Returns:
+        {
+            "session_id": str,
+            "generations": [...],
+            "tool_uses": [...],
+            "prompts": [...],
+            "metadata": {...},
+        }
+    """
+    generations_by_msg_id = {}  # msg_id -> (generation_dict, [tool_uses])
+    generations_order = []      # preserve insertion order of msg_ids
+    tool_results = {}           # tool_use_id -> result content
+    prompts = []                # {prompt_id, timestamp, text}
+    metadata = {}
+
+    session_id = ""
+    privacy_mode = config.get("privacy_mode", False)
+
+    # Maps for resolving promptId via parentUuid chains.
+    # Assistant messages don't carry promptId directly — it lives on the
+    # originating user message. We walk parentUuid up the chain to find it.
+    uuid_to_prompt_id = {}  # uuid -> promptId
+    uuid_to_parent = {}     # uuid -> parentUuid
+
+    # First pass: build UUID maps
+    with open(jsonl_path) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            uid = entry.get("uuid", "")
+            if uid:
+                parent = entry.get("parentUuid", "")
+                if parent:
+                    uuid_to_parent[uid] = parent
+                prompt_id = entry.get("promptId", "")
+                if prompt_id:
+                    uuid_to_prompt_id[uid] = prompt_id
+
+    def resolve_prompt_id(entry_uuid: str) -> str:
+        """Walk parentUuid chain to find the promptId."""
+        current = entry_uuid
+        for _ in range(30):
+            if current in uuid_to_prompt_id:
+                return uuid_to_prompt_id[current]
+            parent = uuid_to_parent.get(current)
+            if not parent:
+                break
+            current = parent
+        return ""
+
+    # Second pass: extract data
+    with open(jsonl_path) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            entry_type = entry.get("type", "")
+
+            # Session metadata
+            if entry_type == "permission-mode":
+                session_id = entry.get("sessionId", "")
+
+            # User messages (prompts + tool results)
+            if entry_type == "user":
+                _process_user_entry(
+                    entry, privacy_mode, tool_results, prompts,
+                    uuid_to_prompt_id,
+                )
+
+            # Assistant messages (generations)
+            if entry_type == "assistant":
+                _process_assistant_entry(
+                    entry, resolve_prompt_id,
+                    generations_by_msg_id, generations_order,
+                )
+
+            # Session summary
+            if entry_type == "system" and entry.get("subtype") == "turn_duration":
+                metadata["duration_ms"] = entry.get("durationMs")
+                metadata["message_count"] = entry.get("messageCount")
+                if not session_id:
+                    session_id = entry.get("sessionId", "")
+
+            # Capture metadata from any entry
+            if not metadata.get("version"):
+                metadata["version"] = entry.get("version", "")
+            if not metadata.get("cwd"):
+                metadata["cwd"] = entry.get("cwd", "")
+            if not metadata.get("git_branch"):
+                metadata["git_branch"] = entry.get("gitBranch", "")
+
+    # Flatten deduplicated generations and tool uses
+    generations = []
+    tool_uses = []
+    for key in generations_order:
+        gen, tus = generations_by_msg_id[key]
+        generations.append(gen)
+        tool_uses.extend(tus)
+
+    # Attach tool results to tool uses
+    for tu in tool_uses:
+        result = tool_results.get(tu["tool_use_id"])
+        if result:
+            tu["result"] = result
+
+    return {
+        "session_id": session_id,
+        "generations": generations,
+        "tool_uses": tool_uses,
+        "prompts": prompts,
+        "metadata": metadata,
+    }
+
+
+def _process_user_entry(
+    entry: dict,
+    privacy_mode: bool,
+    tool_results: dict,
+    prompts: list,
+    uuid_to_prompt_id: dict,
+) -> None:
+    """Process a user-type JSONL entry."""
+    msg = entry.get("message", {})
+    if msg.get("role") != "user":
+        return
+
+    prompt_id = entry.get("promptId", "")
+    timestamp = entry.get("timestamp", "")
+
+    # Check for tool results (two formats)
+    tool_result_top = entry.get("toolUseResult")
+    has_tool_result = False
+
+    if tool_result_top:
+        source_tool_id = entry.get("sourceToolUseID", "")
+        if source_tool_id:
+            tool_results[source_tool_id] = tool_result_top
+            has_tool_result = True
+
+    msg_content = msg.get("content", "")
+    if isinstance(msg_content, list):
+        for item in msg_content:
+            if isinstance(item, dict) and item.get("type") == "tool_result":
+                tool_use_id = item.get("tool_use_id", "")
+                if tool_use_id:
+                    tool_results[tool_use_id] = item
+                    has_tool_result = True
+
+    if has_tool_result or entry.get("isMeta"):
+        return
+
+    # It's a user prompt (or slash command invocation)
+    content = msg_content
+    if isinstance(content, list):
+        text_parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text_parts.append(item.get("text", ""))
+        content = "\n".join(text_parts)
+
+    if not isinstance(content, str) or not content.strip():
+        return
+
+    # Use promptId if available, otherwise fall back to the entry's uuid
+    # so slash commands (which lack a promptId) still get captured.
+    effective_prompt_id = prompt_id or entry.get("uuid", str(uuid.uuid4()))
+    entry_uuid = entry.get("uuid", "")
+    if entry_uuid and effective_prompt_id:
+        uuid_to_prompt_id[entry_uuid] = effective_prompt_id
+
+    prompts.append({
+        "prompt_id": effective_prompt_id,
+        "timestamp": timestamp,
+        "text": content if not privacy_mode else None,
+    })
+
+
+def _process_assistant_entry(
+    entry: dict,
+    resolve_prompt_id,
+    generations_by_msg_id: dict,
+    generations_order: list,
+) -> None:
+    """Process an assistant-type JSONL entry.
+
+    Session logs can have duplicate entries for the same message
+    (streaming updates). The later entry is more complete (has
+    tool_use blocks), so we overwrite earlier entries per message ID.
+    """
+    msg = entry.get("message", {})
+    if msg.get("role") != "assistant":
+        return
+
+    msg_id = msg.get("id", "")
+    usage = msg.get("usage", {})
+    model = msg.get("model", "unknown")
+    stop_reason = msg.get("stop_reason")
+    timestamp = entry.get("timestamp", "")
+    entry_uuid = entry.get("uuid", "")
+    prompt_id = resolve_prompt_id(entry_uuid)
+    span_id = str(uuid.uuid4())
+
+    # Extract text, thinking blocks, and tool_use blocks
+    content = msg.get("content", [])
+    text_parts = []
+    entry_tool_uses = []
+
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    text_parts.append(item.get("text", ""))
+                elif item.get("type") == "thinking":
+                    thinking_text = item.get("thinking", "")
+                    if thinking_text:
+                        text_parts.append(thinking_text)
+                elif item.get("type") == "tool_use":
+                    entry_tool_uses.append({
+                        "tool_use_id": item.get("id", ""),
+                        "name": item.get("name", "unknown"),
+                        "input": item.get("input"),
+                        "generation_span_id": span_id,
+                        "prompt_id": prompt_id,
+                        "timestamp": timestamp,
+                    })
+
+    output_text = "\n".join(text_parts) if text_parts else None
+
+    tool_use_blocks = [
+        {"type": "tool_use", "name": tu["name"]}
+        for tu in entry_tool_uses
+    ]
+
+    generation = {
+        "model": model,
+        "input_tokens": usage.get("input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+        "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
+        "cache_creation_tokens": usage.get("cache_creation_input_tokens", 0),
+        "stop_reason": stop_reason,
+        "timestamp": timestamp,
+        "prompt_id": prompt_id,
+        "span_id": span_id,
+        "output_text": output_text,
+        "tool_use_blocks": tool_use_blocks,
+        "is_error": stop_reason == "error",
+        "error_message": msg.get("error_message"),
+    }
+
+    key = msg_id or entry_uuid or str(uuid.uuid4())
+    if key not in generations_by_msg_id:
+        generations_order.append(key)
+    generations_by_msg_id[key] = (generation, entry_tool_uses)

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -7,9 +7,10 @@ prompts, and metadata into a structured dict.
 import json
 import uuid
 from pathlib import Path
+from typing import Optional
 
 
-def find_session_log(session_id: str, cwd: str) -> str | None:
+def find_session_log(session_id: str, cwd: str) -> Optional[str]:
     """Find the JSONL session log file.
 
     Claude Code stores logs at:

--- a/posthog_llma/sender.py
+++ b/posthog_llma/sender.py
@@ -1,0 +1,93 @@
+"""Send batches of events to PostHog and manage status file."""
+
+import json
+import os
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+
+DEFAULT_HOST = "https://us.i.posthog.com"
+STATUS_FILE = os.path.expanduser("~/.claude/posthog-llma-status.json")
+
+
+def send_batch(
+    events: list[dict],
+    *,
+    api_key: str,
+    host: str = DEFAULT_HOST,
+    distinct_id: str,
+) -> dict:
+    """Send a batch of events to PostHog's /batch endpoint.
+
+    Each event dict must have 'event' and 'properties' keys,
+    and optionally a 'timestamp' key.
+
+    Returns {"status": "ok", "sent": N} on success or
+    {"status": "error", "error": str}.
+    """
+    if not events:
+        return {"status": "ok", "sent": 0}
+
+    batch = []
+    fallback_ts = datetime.now(timezone.utc).isoformat()
+
+    for ev in events:
+        batch.append({
+            "event": ev["event"],
+            "properties": {
+                **ev["properties"],
+                "$lib": "posthog-ai-plugin",
+            },
+            "distinct_id": distinct_id,
+            "timestamp": ev.get("timestamp") or fallback_ts,
+        })
+
+    payload = json.dumps({
+        "api_key": api_key,
+        "batch": batch,
+    }).encode("utf-8")
+
+    url = f"{host.rstrip('/')}/batch"
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "posthog-ai-plugin/1.0",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return {"status": "ok", "sent": len(batch), "response_code": resp.status}
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            pass
+        return {"status": "error", "error": f"HTTP {e.code}: {body}"}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def write_status(status: dict) -> None:
+    """Write last send status for /posthog:llma-cc-status to read."""
+    status["timestamp"] = datetime.now(timezone.utc).isoformat()
+    try:
+        os.makedirs(os.path.dirname(STATUS_FILE), exist_ok=True)
+        with open(STATUS_FILE, "w") as f:
+            json.dump(status, f, indent=2)
+    except OSError:
+        pass
+
+
+def read_status() -> dict | None:
+    """Read last send status."""
+    try:
+        with open(STATUS_FILE) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None

--- a/posthog_llma/sender.py
+++ b/posthog_llma/sender.py
@@ -5,6 +5,7 @@ import os
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone
+from typing import Optional
 
 DEFAULT_HOST = "https://us.i.posthog.com"
 STATUS_FILE = os.path.expanduser("~/.claude/posthog-llma-status.json")
@@ -84,7 +85,7 @@ def write_status(status: dict) -> None:
         pass
 
 
-def read_status() -> dict | None:
+def read_status() -> Optional[dict]:
     """Read last send status."""
     try:
         with open(STATUS_FILE) as f:

--- a/posthog_llma/trace_naming.py
+++ b/posthog_llma/trace_naming.py
@@ -1,6 +1,7 @@
 """Trace name selection from user prompts."""
 
 import re
+from typing import Optional
 
 # Prompts that are framework noise — skip when picking a trace name
 _SKIP_PROMPTS = re.compile(
@@ -17,7 +18,7 @@ def clean_trace_name(text: str, max_len: int = 100) -> str:
     return cleaned[:max_len] if cleaned else text[:max_len]
 
 
-def find_trace_name(prompts: list[dict], max_len: int = 100) -> str | None:
+def find_trace_name(prompts: list[dict], max_len: int = 100) -> Optional[str]:
     """Find the first meaningful user prompt to use as a trace name.
 
     Skips framework noise like /clear, /exit, [Request interrupted] etc.

--- a/posthog_llma/trace_naming.py
+++ b/posthog_llma/trace_naming.py
@@ -1,0 +1,36 @@
+"""Trace name selection from user prompts."""
+
+import re
+
+# Prompts that are framework noise — skip when picking a trace name
+_SKIP_PROMPTS = re.compile(
+    r"^(/clear|/exit|/quit|/help|/compact|/reload|clear|exit|quit|"
+    r"\[Request interrupted|\[Request cancelled)",
+    re.IGNORECASE,
+)
+
+
+def clean_trace_name(text: str, max_len: int = 100) -> str:
+    """Strip XML/HTML tags and truncate for use as a trace name."""
+    cleaned = re.sub(r"<[^>]+>", "", text).strip()
+    cleaned = " ".join(cleaned.split())
+    return cleaned[:max_len] if cleaned else text[:max_len]
+
+
+def find_trace_name(prompts: list[dict], max_len: int = 100) -> str | None:
+    """Find the first meaningful user prompt to use as a trace name.
+
+    Skips framework noise like /clear, /exit, [Request interrupted] etc.
+    Falls back to the first prompt if all are noisy.
+    """
+    for p in prompts:
+        text = p.get("text", "")
+        if not text:
+            continue
+        cleaned = clean_trace_name(text, max_len)
+        if cleaned and not _SKIP_PROMPTS.match(cleaned):
+            return cleaned
+    # Fallback: use whatever the first prompt is, even if noisy
+    if prompts and prompts[0].get("text"):
+        return clean_trace_name(prompts[0]["text"], max_len)
+    return None

--- a/scripts/llma_cc_ingest.py
+++ b/scripts/llma_cc_ingest.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Manually ingest a Claude Code session log into PostHog LLM Analytics.
+
+Usage:
+    python3 llma_cc_ingest.py                          # most recent session for cwd
+    python3 llma_cc_ingest.py <session-id>             # by session ID
+    python3 llma_cc_ingest.py <path-to-jsonl>          # by file path
+    python3 llma_cc_ingest.py --list                   # list recent sessions
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Add scripts/ dir to path for posthog_llma import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import posthog_llma  # noqa: E402
+
+# Import the session parser from hooks/
+PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(PLUGIN_ROOT, "hooks"))
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "session_end_llma",
+    os.path.join(PLUGIN_ROOT, "hooks", "session-end-llma.py"),
+)
+session_end_llma = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(session_end_llma)
+
+
+def find_project_dir() -> Path | None:
+    """Find the Claude projects directory for the current working directory."""
+    cwd = os.getcwd()
+    project_dir_name = cwd.replace("/", "-")
+    project_dir = Path.home() / ".claude" / "projects" / project_dir_name
+    if project_dir.is_dir():
+        return project_dir
+    return None
+
+
+def list_sessions(project_dir: Path | None = None, limit: int = 10) -> list[dict]:
+    """List recent session logs."""
+    if project_dir:
+        jsonl_files = list(project_dir.glob("*.jsonl"))
+    else:
+        projects_dir = Path.home() / ".claude" / "projects"
+        jsonl_files = list(projects_dir.glob("**/*.jsonl"))
+
+    jsonl_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    sessions = []
+
+    for f in jsonl_files[:limit]:
+        session_id = f.stem
+        size_kb = f.stat().st_size / 1024
+        # Peek at first user prompt
+        first_prompt = ""
+        try:
+            with open(f) as fh:
+                for line in fh:
+                    entry = json.loads(line)
+                    if (entry.get("type") == "user"
+                            and not entry.get("toolUseResult")
+                            and not entry.get("isMeta")):
+                        msg = entry.get("message", {}).get("content", "")
+                        if isinstance(msg, str) and msg.strip():
+                            first_prompt = msg.strip()[:60]
+                            break
+                        elif isinstance(msg, list):
+                            for item in msg:
+                                if isinstance(item, dict) and item.get("type") == "text":
+                                    first_prompt = item.get("text", "").strip()[:60]
+                                    break
+                            if first_prompt:
+                                break
+        except (json.JSONDecodeError, OSError):
+            pass
+
+        sessions.append({
+            "session_id": session_id,
+            "path": str(f),
+            "size_kb": round(size_kb, 1),
+            "first_prompt": first_prompt,
+            "project": f.parent.name,
+        })
+
+    return sessions
+
+
+def resolve_session_path(arg: str) -> str | None:
+    """Resolve a session ID or path to a JSONL file path."""
+    # Direct file path
+    expanded = os.path.expanduser(arg)
+    if os.path.isfile(expanded):
+        return expanded
+
+    # Session ID — search for it
+    projects_dir = Path.home() / ".claude" / "projects"
+    matches = list(projects_dir.glob(f"**/{arg}.jsonl"))
+    if matches:
+        return str(matches[0])
+
+    # Partial match
+    matches = list(projects_dir.glob(f"**/{arg}*.jsonl"))
+    if len(matches) == 1:
+        return str(matches[0])
+    elif len(matches) > 1:
+        print(f"Multiple matches for '{arg}':")
+        for m in matches:
+            print(f"  {m}")
+        return None
+
+    return None
+
+
+def ingest(jsonl_path: str) -> dict:
+    """Parse and send a session log to PostHog."""
+    api_key = os.environ.get("POSTHOG_API_KEY", "")
+    if not api_key:
+        return {"status": "error", "error": "POSTHOG_API_KEY not set"}
+
+    host = os.environ.get("POSTHOG_HOST", posthog_llma.DEFAULT_HOST)
+    privacy_mode = os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true"
+    trace_grouping = os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session")
+    max_attr = int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000"))
+
+    config = {
+        "privacy_mode": privacy_mode,
+        "max_attribute_length": max_attr,
+        "trace_grouping": trace_grouping,
+    }
+
+    parsed = session_end_llma.parse_session(jsonl_path, config)
+    if not parsed["generations"]:
+        return {"status": "error", "error": "No generations found in session log"}
+
+    events = session_end_llma.build_events(parsed, config)
+    if not events:
+        return {"status": "error", "error": "No events built"}
+
+    # Determine distinct_id
+    distinct_id = os.environ.get("POSTHOG_LLMA_DISTINCT_ID", "")
+    if not distinct_id:
+        try:
+            result = subprocess.run(
+                ["git", "config", "user.email"],
+                capture_output=True, text=True, timeout=2,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                distinct_id = result.stdout.strip()
+        except Exception:
+            pass
+    if not distinct_id:
+        distinct_id = f"claude-code:{parsed['session_id']}"
+
+    result = posthog_llma.send_batch(
+        events,
+        api_key=api_key,
+        host=host,
+        distinct_id=distinct_id,
+    )
+
+    gen_count = sum(1 for e in events if e["event"] == "$ai_generation")
+    span_count = sum(1 for e in events if e["event"] == "$ai_span")
+    trace_count = sum(1 for e in events if e["event"] == "$ai_trace")
+
+    return {
+        **result,
+        "session_id": parsed["session_id"],
+        "generations": gen_count,
+        "spans": span_count,
+        "traces": trace_count,
+        "total_events": len(events),
+        "host": host,
+        "distinct_id": distinct_id,
+    }
+
+
+def main():
+    args = sys.argv[1:]
+
+    if not args or args == [""]:
+        # Most recent session for current project
+        project_dir = find_project_dir()
+        if not project_dir:
+            print("No Claude Code sessions found for the current directory.")
+            print("Use --list to see all sessions, or provide a session ID or path.")
+            sys.exit(1)
+
+        sessions = list_sessions(project_dir, limit=1)
+        if not sessions:
+            print("No session logs found.")
+            sys.exit(1)
+
+        jsonl_path = sessions[0]["path"]
+        print(f"Ingesting most recent session: {sessions[0]['session_id']}")
+        if sessions[0]["first_prompt"]:
+            print(f"  First prompt: {sessions[0]['first_prompt']}")
+
+    elif args[0] == "--list":
+        project_dir = find_project_dir()
+        sessions = list_sessions(project_dir, limit=10)
+        if not sessions:
+            print("No session logs found.")
+            sys.exit(0)
+
+        print(f"Recent sessions ({len(sessions)}):\n")
+        for s in sessions:
+            prompt = f' — "{s["first_prompt"]}"' if s["first_prompt"] else ""
+            print(f"  {s['session_id']}  ({s['size_kb']}KB){prompt}")
+        print(f"\nUsage: python3 {sys.argv[0]} <session-id>")
+        sys.exit(0)
+
+    else:
+        jsonl_path = resolve_session_path(args[0])
+        if not jsonl_path:
+            print(f"Could not find session: {args[0]}")
+            sys.exit(1)
+        print(f"Ingesting: {jsonl_path}")
+
+    result = ingest(jsonl_path)
+    print(json.dumps(result, indent=2))
+    sys.exit(0 if result.get("status") == "ok" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/llma_cc_ingest.py
+++ b/scripts/llma_cc_ingest.py
@@ -118,10 +118,21 @@ def ingest(jsonl_path: str) -> dict:
     trace_grouping = os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session")
     max_attr = int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000"))
 
+    custom_props = {}
+    raw = os.environ.get("POSTHOG_LLMA_CUSTOM_PROPERTIES", "")
+    if raw:
+        try:
+            parsed_props = json.loads(raw)
+            if isinstance(parsed_props, dict):
+                custom_props = parsed_props
+        except (json.JSONDecodeError, ValueError):
+            pass
+
     config = {
         "privacy_mode": privacy_mode,
         "max_attribute_length": max_attr,
         "trace_grouping": trace_grouping,
+        "custom_properties": custom_props,
     }
 
     parsed = parse_session(jsonl_path, config)

--- a/scripts/llma_cc_ingest.py
+++ b/scripts/llma_cc_ingest.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 # Add plugin root to path
 PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -26,7 +27,7 @@ from posthog_llma import (  # noqa: E402
 )
 
 
-def find_project_dir() -> Path | None:
+def find_project_dir() -> Optional[Path]:
     """Find the Claude projects directory for the current working directory."""
     cwd = os.getcwd()
     project_dir_name = cwd.replace("/", "-")
@@ -36,7 +37,7 @@ def find_project_dir() -> Path | None:
     return None
 
 
-def list_sessions(project_dir: Path | None = None, limit: int = 10) -> list[dict]:
+def list_sessions(project_dir: Optional[Path] = None, limit: int = 10) -> list[dict]:
     """List recent session logs."""
     if project_dir:
         jsonl_files = list(project_dir.glob("*.jsonl"))
@@ -83,7 +84,7 @@ def list_sessions(project_dir: Path | None = None, limit: int = 10) -> list[dict
     return sessions
 
 
-def resolve_session_path(arg: str) -> str | None:
+def resolve_session_path(arg: str) -> Optional[str]:
     """Resolve a session ID or path to a JSONL file path."""
     expanded = os.path.expanduser(arg)
     if os.path.isfile(expanded):

--- a/scripts/llma_cc_ingest.py
+++ b/scripts/llma_cc_ingest.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Manually ingest a Claude Code session log into PostHog LLM Analytics.
+"""Manually ingest a Claude Code session log into PostHog LLM Analytics.
 
 Usage:
     python3 llma_cc_ingest.py                          # most recent session for cwd
@@ -15,23 +14,16 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Add scripts/ dir to path for posthog_llma import
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-import posthog_llma  # noqa: E402
-
-# Import the session parser from hooks/
+# Add plugin root to path
 PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, os.path.join(PLUGIN_ROOT, "hooks"))
+sys.path.insert(0, PLUGIN_ROOT)
 
-import importlib.util
-
-_spec = importlib.util.spec_from_file_location(
-    "session_end_llma",
-    os.path.join(PLUGIN_ROOT, "hooks", "session-end-llma.py"),
+from posthog_llma import (  # noqa: E402
+    parse_session,
+    build_events,
+    send_batch,
+    DEFAULT_HOST,
 )
-session_end_llma = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(session_end_llma)
 
 
 def find_project_dir() -> Path | None:
@@ -58,7 +50,6 @@ def list_sessions(project_dir: Path | None = None, limit: int = 10) -> list[dict
     for f in jsonl_files[:limit]:
         session_id = f.stem
         size_kb = f.stat().st_size / 1024
-        # Peek at first user prompt
         first_prompt = ""
         try:
             with open(f) as fh:
@@ -94,18 +85,15 @@ def list_sessions(project_dir: Path | None = None, limit: int = 10) -> list[dict
 
 def resolve_session_path(arg: str) -> str | None:
     """Resolve a session ID or path to a JSONL file path."""
-    # Direct file path
     expanded = os.path.expanduser(arg)
     if os.path.isfile(expanded):
         return expanded
 
-    # Session ID — search for it
     projects_dir = Path.home() / ".claude" / "projects"
     matches = list(projects_dir.glob(f"**/{arg}.jsonl"))
     if matches:
         return str(matches[0])
 
-    # Partial match
     matches = list(projects_dir.glob(f"**/{arg}*.jsonl"))
     if len(matches) == 1:
         return str(matches[0])
@@ -124,7 +112,7 @@ def ingest(jsonl_path: str) -> dict:
     if not api_key:
         return {"status": "error", "error": "POSTHOG_API_KEY not set"}
 
-    host = os.environ.get("POSTHOG_HOST", posthog_llma.DEFAULT_HOST)
+    host = os.environ.get("POSTHOG_HOST", DEFAULT_HOST)
     privacy_mode = os.environ.get("POSTHOG_LLMA_PRIVACY_MODE", "false").lower() == "true"
     trace_grouping = os.environ.get("POSTHOG_LLMA_TRACE_GROUPING", "session")
     max_attr = int(os.environ.get("POSTHOG_LLMA_MAX_ATTRIBUTE_LENGTH", "12000"))
@@ -135,15 +123,14 @@ def ingest(jsonl_path: str) -> dict:
         "trace_grouping": trace_grouping,
     }
 
-    parsed = session_end_llma.parse_session(jsonl_path, config)
+    parsed = parse_session(jsonl_path, config)
     if not parsed["generations"]:
         return {"status": "error", "error": "No generations found in session log"}
 
-    events = session_end_llma.build_events(parsed, config)
+    events = build_events(parsed, config)
     if not events:
         return {"status": "error", "error": "No events built"}
 
-    # Determine distinct_id
     distinct_id = os.environ.get("POSTHOG_LLMA_DISTINCT_ID", "")
     if not distinct_id:
         try:
@@ -158,7 +145,7 @@ def ingest(jsonl_path: str) -> dict:
     if not distinct_id:
         distinct_id = f"claude-code:{parsed['session_id']}"
 
-    result = posthog_llma.send_batch(
+    result = send_batch(
         events,
         api_key=api_key,
         host=host,
@@ -185,7 +172,6 @@ def main():
     args = sys.argv[1:]
 
     if not args or args == [""]:
-        # Most recent session for current project
         project_dir = find_project_dir()
         if not project_dir:
             print("No Claude Code sessions found for the current directory.")

--- a/scripts/posthog_llma.py
+++ b/scripts/posthog_llma.py
@@ -1,0 +1,275 @@
+"""
+PostHog LLM Analytics - Generic event builder and sender.
+
+Builds $ai_generation, $ai_span, and $ai_trace events in PostHog's
+LLM analytics format and sends them via the /batch capture endpoint.
+
+This module is client-agnostic — it takes structured data and produces
+PostHog events. Client-specific parsers (e.g. session-end-llma.py for
+Claude Code) feed data into this module.
+
+Zero dependencies — uses only Python stdlib.
+"""
+
+import json
+import os
+import urllib.request
+import urllib.error
+import uuid
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Event builders
+#
+# Note: cost calculation ($ai_total_cost_usd etc.) is handled by PostHog's
+# ingestion pipeline automatically from $ai_model + token counts. We do NOT
+# need to calculate or send cost — just send model and tokens.
+# ---------------------------------------------------------------------------
+
+def build_ai_generation(
+    *,
+    model: str,
+    provider: str = "anthropic",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    latency_seconds: float | None = None,
+    stop_reason: str | None = None,
+    is_error: bool = False,
+    error_message: str | None = None,
+    trace_id: str,
+    span_id: str | None = None,
+    session_id: str,
+    input_messages: object = None,
+    output_choices: object = None,
+    user_prompt: str | None = None,
+    project_name: str = "",
+    agent_name: str = "",
+    privacy_mode: bool = False,
+    extra_properties: dict | None = None,
+    timestamp: str | None = None,
+) -> dict:
+    """Build a $ai_generation event.
+
+    Cost ($ai_total_cost_usd etc.) is calculated by PostHog's ingestion
+    pipeline from $ai_model + token counts — we don't send it.
+    """
+    total_tokens = input_tokens + output_tokens
+
+    # Map Claude Code stop reasons to PostHog's expected values
+    stop_map = {"end_turn": "stop", "tool_use": "tool_calls", "max_tokens": "length"}
+    mapped_stop = stop_map.get(stop_reason, stop_reason) if stop_reason else None
+
+    properties = {
+        "$ai_model": model,
+        "$ai_provider": provider,
+        "$ai_input_tokens": input_tokens,
+        "$ai_output_tokens": output_tokens,
+        "$ai_total_tokens": total_tokens,
+        "$ai_latency": latency_seconds,
+        "$ai_stop_reason": mapped_stop,
+        "$ai_is_error": is_error,
+        "$ai_error": error_message,
+        "$ai_trace_id": trace_id,
+        "$ai_span_id": span_id or str(uuid.uuid4()),
+        "$ai_session_id": session_id,
+        "$ai_input": None if privacy_mode else input_messages,
+        "$ai_output_choices": None if privacy_mode else output_choices,
+        "$ai_lib": "posthog-ai-plugin",
+        "$ai_framework": "claude-code",
+        "$ai_project_name": project_name,
+        "$ai_agent_name": agent_name,
+        "cache_read_input_tokens": cache_read_tokens,
+        "cache_creation_input_tokens": cache_creation_tokens,
+    }
+
+    if user_prompt and not privacy_mode:
+        properties["$ai_user_prompt"] = user_prompt
+
+    if extra_properties:
+        properties.update(extra_properties)
+
+    result = {"event": "$ai_generation", "properties": properties}
+    if timestamp:
+        result["timestamp"] = timestamp
+    return result
+
+
+def build_ai_span(
+    *,
+    span_name: str,
+    trace_id: str,
+    parent_span_id: str | None = None,
+    span_id: str | None = None,
+    session_id: str,
+    latency_seconds: float | None = None,
+    input_state: object = None,
+    output_state: object = None,
+    is_error: bool = False,
+    error_message: str | None = None,
+    project_name: str = "",
+    agent_name: str = "",
+    privacy_mode: bool = False,
+    max_attribute_length: int = 12000,
+    timestamp: str | None = None,
+) -> dict:
+    """Build a $ai_span event for a tool execution."""
+    def _truncate(val, max_len):
+        if val is None:
+            return None
+        s = json.dumps(val) if not isinstance(val, str) else val
+        return s[:max_len] if len(s) > max_len else s
+
+    properties = {
+        "$ai_span_name": span_name,
+        "$ai_trace_id": trace_id,
+        "$ai_span_id": span_id or str(uuid.uuid4()),
+        "$ai_parent_id": parent_span_id,
+        "$ai_session_id": session_id,
+        "$ai_latency": latency_seconds,
+        "$ai_input_state": None if privacy_mode else _truncate(input_state, max_attribute_length),
+        "$ai_output_state": None if privacy_mode else _truncate(output_state, max_attribute_length),
+        "$ai_is_error": is_error,
+        "$ai_error": error_message,
+        "$ai_lib": "posthog-ai-plugin",
+        "$ai_framework": "claude-code",
+        "$ai_project_name": project_name,
+        "$ai_agent_name": agent_name,
+    }
+
+    result = {"event": "$ai_span", "properties": properties}
+    if timestamp:
+        result["timestamp"] = timestamp
+    return result
+
+
+def build_ai_trace(
+    *,
+    trace_id: str,
+    session_id: str,
+    trace_name: str | None = None,
+    latency_seconds: float | None = None,
+    total_input_tokens: int = 0,
+    total_output_tokens: int = 0,
+    is_error: bool = False,
+    error_message: str | None = None,
+    project_name: str = "",
+    agent_name: str = "",
+    timestamp: str | None = None,
+) -> dict:
+    """Build a $ai_trace event for a complete prompt→response cycle."""
+    properties = {
+        "$ai_trace_id": trace_id,
+        "$ai_trace_name": trace_name,
+        "$ai_session_id": session_id,
+        "$ai_latency": latency_seconds,
+        "$ai_total_input_tokens": total_input_tokens,
+        "$ai_total_output_tokens": total_output_tokens,
+        "$ai_is_error": is_error,
+        "$ai_error": error_message,
+        "$ai_lib": "posthog-ai-plugin",
+        "$ai_framework": "claude-code",
+        "$ai_project_name": project_name,
+        "$ai_agent_name": agent_name,
+    }
+
+    result = {"event": "$ai_trace", "properties": properties}
+    if timestamp:
+        result["timestamp"] = timestamp
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sender
+# ---------------------------------------------------------------------------
+
+DEFAULT_HOST = "https://us.i.posthog.com"
+
+
+def send_batch(
+    events: list[dict],
+    *,
+    api_key: str,
+    host: str = DEFAULT_HOST,
+    distinct_id: str,
+) -> dict:
+    """Send a batch of events to PostHog's /batch endpoint.
+
+    Each event dict must have 'event' and 'properties' keys.
+    Returns {"status": "ok", "sent": N} on success or {"status": "error", "error": str}.
+    """
+    if not events:
+        return {"status": "ok", "sent": 0}
+
+    batch = []
+    fallback_ts = datetime.now(timezone.utc).isoformat()
+
+    for ev in events:
+        batch.append({
+            "event": ev["event"],
+            "properties": {
+                **ev["properties"],
+                "$lib": "posthog-ai-plugin",
+            },
+            "distinct_id": distinct_id,
+            "timestamp": ev.get("timestamp") or fallback_ts,
+        })
+
+    payload = json.dumps({
+        "api_key": api_key,
+        "batch": batch,
+    }).encode("utf-8")
+
+    url = f"{host.rstrip('/')}/batch"
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "posthog-ai-plugin/1.0",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return {"status": "ok", "sent": len(batch), "response_code": resp.status}
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            pass
+        return {"status": "error", "error": f"HTTP {e.code}: {body}"}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Status file helpers
+# ---------------------------------------------------------------------------
+
+STATUS_FILE = os.path.expanduser("~/.claude/posthog-llma-status.json")
+
+
+def write_status(status: dict) -> None:
+    """Write last send status to a file for /posthog:llma-status to read."""
+    status["timestamp"] = datetime.now(timezone.utc).isoformat()
+    try:
+        os.makedirs(os.path.dirname(STATUS_FILE), exist_ok=True)
+        with open(STATUS_FILE, "w") as f:
+            json.dump(status, f, indent=2)
+    except OSError:
+        pass
+
+
+def read_status() -> dict | None:
+    """Read last send status."""
+    try:
+        with open(STATUS_FILE) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -1,4 +1,4 @@
-"""Tests for the generic PostHog LLM Analytics event builder."""
+"""Tests for the PostHog LLM Analytics event builders and sender."""
 
 import os
 import sys
@@ -6,8 +6,11 @@ import tempfile
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-import posthog_llma
+# Add plugin root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
+from posthog_llma.sender import send_batch, write_status, read_status, STATUS_FILE
 
 
 # ---------------------------------------------------------------------------
@@ -17,7 +20,7 @@ import posthog_llma
 
 class TestBuildAiGeneration:
     def test_basic_generation(self):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="claude-opus-4-6",
             input_tokens=100,
             output_tokens=50,
@@ -42,13 +45,13 @@ class TestBuildAiGeneration:
         ("error", "error"),
     ])
     def test_stop_reason_mapping(self, cc_reason, expected):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", stop_reason=cc_reason, trace_id="t", session_id="s",
         )
         assert ev["properties"]["$ai_stop_reason"] == expected
 
     def test_privacy_mode_redacts(self):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", trace_id="t", session_id="s",
             input_messages=[{"role": "user", "content": "secret"}],
             output_choices=[{"role": "assistant", "content": "answer"}],
@@ -61,7 +64,7 @@ class TestBuildAiGeneration:
         assert "$ai_user_prompt" not in props
 
     def test_privacy_mode_off_includes_content(self):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", trace_id="t", session_id="s",
             input_messages=[{"role": "user", "content": "hello"}],
             output_choices=[{"role": "assistant", "content": "hi"}],
@@ -74,20 +77,20 @@ class TestBuildAiGeneration:
         assert props["$ai_user_prompt"] == "hello"
 
     def test_timestamp_passthrough(self):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", trace_id="t", session_id="s",
             timestamp="2026-04-12T21:00:00Z",
         )
         assert ev["timestamp"] == "2026-04-12T21:00:00Z"
 
     def test_no_timestamp_means_no_key(self):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", trace_id="t", session_id="s",
         )
         assert "timestamp" not in ev
 
     def test_cache_tokens(self):
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", trace_id="t", session_id="s",
             input_tokens=10, output_tokens=20,
             cache_read_tokens=5, cache_creation_tokens=3,
@@ -98,7 +101,7 @@ class TestBuildAiGeneration:
 
     def test_no_cost_properties(self):
         """Cost is calculated by PostHog ingestion, we should not send it."""
-        ev = posthog_llma.build_ai_generation(
+        ev = build_ai_generation(
             model="m", trace_id="t", session_id="s",
             input_tokens=100, output_tokens=50,
         )
@@ -115,7 +118,7 @@ class TestBuildAiGeneration:
 
 class TestBuildAiSpan:
     def test_basic_span(self):
-        ev = posthog_llma.build_ai_span(
+        ev = build_ai_span(
             span_name="Bash",
             trace_id="trace-1",
             session_id="session-1",
@@ -125,14 +128,14 @@ class TestBuildAiSpan:
         assert ev["properties"]["$ai_trace_id"] == "trace-1"
 
     def test_parent_id(self):
-        ev = posthog_llma.build_ai_span(
+        ev = build_ai_span(
             span_name="Bash", trace_id="t", session_id="s",
             parent_span_id="parent-123",
         )
         assert ev["properties"]["$ai_parent_id"] == "parent-123"
 
     def test_privacy_mode_redacts_state(self):
-        ev = posthog_llma.build_ai_span(
+        ev = build_ai_span(
             span_name="Bash", trace_id="t", session_id="s",
             input_state={"command": "ls"},
             output_state="file list",
@@ -142,7 +145,7 @@ class TestBuildAiSpan:
         assert ev["properties"]["$ai_output_state"] is None
 
     def test_truncation(self):
-        ev = posthog_llma.build_ai_span(
+        ev = build_ai_span(
             span_name="Bash", trace_id="t", session_id="s",
             input_state="x" * 20000,
             max_attribute_length=100,
@@ -150,7 +153,7 @@ class TestBuildAiSpan:
         assert len(ev["properties"]["$ai_input_state"]) == 100
 
     def test_timestamp_passthrough(self):
-        ev = posthog_llma.build_ai_span(
+        ev = build_ai_span(
             span_name="Bash", trace_id="t", session_id="s",
             timestamp="2026-04-12T21:00:00Z",
         )
@@ -164,7 +167,7 @@ class TestBuildAiSpan:
 
 class TestBuildAiTrace:
     def test_basic_trace(self):
-        ev = posthog_llma.build_ai_trace(
+        ev = build_ai_trace(
             trace_id="trace-1",
             session_id="session-1",
             total_input_tokens=1000,
@@ -176,14 +179,14 @@ class TestBuildAiTrace:
         assert ev["properties"]["$ai_total_output_tokens"] == 5000
 
     def test_trace_name(self):
-        ev = posthog_llma.build_ai_trace(
+        ev = build_ai_trace(
             trace_id="t", session_id="s",
             trace_name="help me fix a bug",
         )
         assert ev["properties"]["$ai_trace_name"] == "help me fix a bug"
 
     def test_timestamp_passthrough(self):
-        ev = posthog_llma.build_ai_trace(
+        ev = build_ai_trace(
             trace_id="t", session_id="s",
             timestamp="2026-04-12T21:00:00Z",
         )
@@ -197,17 +200,16 @@ class TestBuildAiTrace:
 
 class TestSendBatch:
     def test_empty_batch(self):
-        result = posthog_llma.send_batch([], api_key="test", distinct_id="user")
+        result = send_batch([], api_key="test", distinct_id="user")
         assert result == {"status": "ok", "sent": 0}
 
     def test_per_event_timestamps_used(self):
-        """Verify batch assembly uses per-event timestamps."""
         from datetime import datetime, timezone
 
         events = [
             {"event": "$ai_generation", "properties": {}, "timestamp": "2026-04-12T10:00:00Z"},
             {"event": "$ai_generation", "properties": {}, "timestamp": "2026-04-12T10:01:00Z"},
-            {"event": "$ai_generation", "properties": {}},  # no timestamp
+            {"event": "$ai_generation", "properties": {}},
         ]
         fallback = datetime.now(timezone.utc).isoformat()
         timestamps = [ev.get("timestamp") or fallback for ev in events]
@@ -223,24 +225,26 @@ class TestSendBatch:
 
 class TestStatusFile:
     def test_write_and_read(self):
+        import posthog_llma.sender as sender_mod
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
             tmp_path = f.name
+        original = sender_mod.STATUS_FILE
         try:
-            original = posthog_llma.STATUS_FILE
-            posthog_llma.STATUS_FILE = tmp_path
-            posthog_llma.write_status({"session_id": "test", "status": "ok"})
-            status = posthog_llma.read_status()
+            sender_mod.STATUS_FILE = tmp_path
+            write_status({"session_id": "test", "status": "ok"})
+            status = read_status()
             assert status["session_id"] == "test"
             assert status["status"] == "ok"
             assert "timestamp" in status
         finally:
-            posthog_llma.STATUS_FILE = original
+            sender_mod.STATUS_FILE = original
             os.unlink(tmp_path)
 
     def test_read_missing_file(self):
-        original = posthog_llma.STATUS_FILE
-        posthog_llma.STATUS_FILE = "/tmp/nonexistent-posthog-llma-test.json"
+        import posthog_llma.sender as sender_mod
+        original = sender_mod.STATUS_FILE
+        sender_mod.STATUS_FILE = "/tmp/nonexistent-posthog-llma-test.json"
         try:
-            assert posthog_llma.read_status() is None
+            assert read_status() is None
         finally:
-            posthog_llma.STATUS_FILE = original
+            sender_mod.STATUS_FILE = original

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -1,0 +1,246 @@
+"""Tests for the generic PostHog LLM Analytics event builder."""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import posthog_llma
+
+
+# ---------------------------------------------------------------------------
+# $ai_generation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAiGeneration:
+    def test_basic_generation(self):
+        ev = posthog_llma.build_ai_generation(
+            model="claude-opus-4-6",
+            input_tokens=100,
+            output_tokens=50,
+            trace_id="trace-1",
+            session_id="session-1",
+        )
+        assert ev["event"] == "$ai_generation"
+        props = ev["properties"]
+        assert props["$ai_model"] == "claude-opus-4-6"
+        assert props["$ai_provider"] == "anthropic"
+        assert props["$ai_input_tokens"] == 100
+        assert props["$ai_output_tokens"] == 50
+        assert props["$ai_total_tokens"] == 150
+        assert props["$ai_trace_id"] == "trace-1"
+        assert props["$ai_session_id"] == "session-1"
+        assert props["$ai_framework"] == "claude-code"
+
+    @pytest.mark.parametrize("cc_reason,expected", [
+        ("end_turn", "stop"),
+        ("tool_use", "tool_calls"),
+        ("max_tokens", "length"),
+        ("error", "error"),
+    ])
+    def test_stop_reason_mapping(self, cc_reason, expected):
+        ev = posthog_llma.build_ai_generation(
+            model="m", stop_reason=cc_reason, trace_id="t", session_id="s",
+        )
+        assert ev["properties"]["$ai_stop_reason"] == expected
+
+    def test_privacy_mode_redacts(self):
+        ev = posthog_llma.build_ai_generation(
+            model="m", trace_id="t", session_id="s",
+            input_messages=[{"role": "user", "content": "secret"}],
+            output_choices=[{"role": "assistant", "content": "answer"}],
+            user_prompt="secret",
+            privacy_mode=True,
+        )
+        props = ev["properties"]
+        assert props["$ai_input"] is None
+        assert props["$ai_output_choices"] is None
+        assert "$ai_user_prompt" not in props
+
+    def test_privacy_mode_off_includes_content(self):
+        ev = posthog_llma.build_ai_generation(
+            model="m", trace_id="t", session_id="s",
+            input_messages=[{"role": "user", "content": "hello"}],
+            output_choices=[{"role": "assistant", "content": "hi"}],
+            user_prompt="hello",
+            privacy_mode=False,
+        )
+        props = ev["properties"]
+        assert props["$ai_input"][0]["content"] == "hello"
+        assert props["$ai_output_choices"][0]["content"] == "hi"
+        assert props["$ai_user_prompt"] == "hello"
+
+    def test_timestamp_passthrough(self):
+        ev = posthog_llma.build_ai_generation(
+            model="m", trace_id="t", session_id="s",
+            timestamp="2026-04-12T21:00:00Z",
+        )
+        assert ev["timestamp"] == "2026-04-12T21:00:00Z"
+
+    def test_no_timestamp_means_no_key(self):
+        ev = posthog_llma.build_ai_generation(
+            model="m", trace_id="t", session_id="s",
+        )
+        assert "timestamp" not in ev
+
+    def test_cache_tokens(self):
+        ev = posthog_llma.build_ai_generation(
+            model="m", trace_id="t", session_id="s",
+            input_tokens=10, output_tokens=20,
+            cache_read_tokens=5, cache_creation_tokens=3,
+        )
+        props = ev["properties"]
+        assert props["cache_read_input_tokens"] == 5
+        assert props["cache_creation_input_tokens"] == 3
+
+    def test_no_cost_properties(self):
+        """Cost is calculated by PostHog ingestion, we should not send it."""
+        ev = posthog_llma.build_ai_generation(
+            model="m", trace_id="t", session_id="s",
+            input_tokens=100, output_tokens=50,
+        )
+        props = ev["properties"]
+        assert "$ai_total_cost_usd" not in props
+        assert "$ai_input_cost_usd" not in props
+        assert "$ai_output_cost_usd" not in props
+
+
+# ---------------------------------------------------------------------------
+# $ai_span
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAiSpan:
+    def test_basic_span(self):
+        ev = posthog_llma.build_ai_span(
+            span_name="Bash",
+            trace_id="trace-1",
+            session_id="session-1",
+        )
+        assert ev["event"] == "$ai_span"
+        assert ev["properties"]["$ai_span_name"] == "Bash"
+        assert ev["properties"]["$ai_trace_id"] == "trace-1"
+
+    def test_parent_id(self):
+        ev = posthog_llma.build_ai_span(
+            span_name="Bash", trace_id="t", session_id="s",
+            parent_span_id="parent-123",
+        )
+        assert ev["properties"]["$ai_parent_id"] == "parent-123"
+
+    def test_privacy_mode_redacts_state(self):
+        ev = posthog_llma.build_ai_span(
+            span_name="Bash", trace_id="t", session_id="s",
+            input_state={"command": "ls"},
+            output_state="file list",
+            privacy_mode=True,
+        )
+        assert ev["properties"]["$ai_input_state"] is None
+        assert ev["properties"]["$ai_output_state"] is None
+
+    def test_truncation(self):
+        ev = posthog_llma.build_ai_span(
+            span_name="Bash", trace_id="t", session_id="s",
+            input_state="x" * 20000,
+            max_attribute_length=100,
+        )
+        assert len(ev["properties"]["$ai_input_state"]) == 100
+
+    def test_timestamp_passthrough(self):
+        ev = posthog_llma.build_ai_span(
+            span_name="Bash", trace_id="t", session_id="s",
+            timestamp="2026-04-12T21:00:00Z",
+        )
+        assert ev["timestamp"] == "2026-04-12T21:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# $ai_trace
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAiTrace:
+    def test_basic_trace(self):
+        ev = posthog_llma.build_ai_trace(
+            trace_id="trace-1",
+            session_id="session-1",
+            total_input_tokens=1000,
+            total_output_tokens=5000,
+        )
+        assert ev["event"] == "$ai_trace"
+        assert ev["properties"]["$ai_trace_id"] == "trace-1"
+        assert ev["properties"]["$ai_total_input_tokens"] == 1000
+        assert ev["properties"]["$ai_total_output_tokens"] == 5000
+
+    def test_trace_name(self):
+        ev = posthog_llma.build_ai_trace(
+            trace_id="t", session_id="s",
+            trace_name="help me fix a bug",
+        )
+        assert ev["properties"]["$ai_trace_name"] == "help me fix a bug"
+
+    def test_timestamp_passthrough(self):
+        ev = posthog_llma.build_ai_trace(
+            trace_id="t", session_id="s",
+            timestamp="2026-04-12T21:00:00Z",
+        )
+        assert ev["timestamp"] == "2026-04-12T21:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# send_batch
+# ---------------------------------------------------------------------------
+
+
+class TestSendBatch:
+    def test_empty_batch(self):
+        result = posthog_llma.send_batch([], api_key="test", distinct_id="user")
+        assert result == {"status": "ok", "sent": 0}
+
+    def test_per_event_timestamps_used(self):
+        """Verify batch assembly uses per-event timestamps."""
+        from datetime import datetime, timezone
+
+        events = [
+            {"event": "$ai_generation", "properties": {}, "timestamp": "2026-04-12T10:00:00Z"},
+            {"event": "$ai_generation", "properties": {}, "timestamp": "2026-04-12T10:01:00Z"},
+            {"event": "$ai_generation", "properties": {}},  # no timestamp
+        ]
+        fallback = datetime.now(timezone.utc).isoformat()
+        timestamps = [ev.get("timestamp") or fallback for ev in events]
+        assert timestamps[0] == "2026-04-12T10:00:00Z"
+        assert timestamps[1] == "2026-04-12T10:01:00Z"
+        assert timestamps[2] == fallback
+
+
+# ---------------------------------------------------------------------------
+# Status file
+# ---------------------------------------------------------------------------
+
+
+class TestStatusFile:
+    def test_write_and_read(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            tmp_path = f.name
+        try:
+            original = posthog_llma.STATUS_FILE
+            posthog_llma.STATUS_FILE = tmp_path
+            posthog_llma.write_status({"session_id": "test", "status": "ok"})
+            status = posthog_llma.read_status()
+            assert status["session_id"] == "test"
+            assert status["status"] == "ok"
+            assert "timestamp" in status
+        finally:
+            posthog_llma.STATUS_FILE = original
+            os.unlink(tmp_path)
+
+    def test_read_missing_file(self):
+        original = posthog_llma.STATUS_FILE
+        posthog_llma.STATUS_FILE = "/tmp/nonexistent-posthog-llma-test.json"
+        try:
+            assert posthog_llma.read_status() is None
+        finally:
+            posthog_llma.STATUS_FILE = original

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -152,6 +152,14 @@ class TestBuildAiSpan:
         )
         assert len(ev["properties"]["$ai_input_state"]) == 100
 
+    def test_extra_properties(self):
+        ev = build_ai_span(
+            span_name="Bash", trace_id="t", session_id="s",
+            extra_properties={"ai_product": "my-app", "team": "platform"},
+        )
+        assert ev["properties"]["ai_product"] == "my-app"
+        assert ev["properties"]["team"] == "platform"
+
     def test_timestamp_passthrough(self):
         ev = build_ai_span(
             span_name="Bash", trace_id="t", session_id="s",
@@ -184,6 +192,13 @@ class TestBuildAiTrace:
             trace_name="help me fix a bug",
         )
         assert ev["properties"]["$ai_trace_name"] == "help me fix a bug"
+
+    def test_extra_properties(self):
+        ev = build_ai_trace(
+            trace_id="t", session_id="s",
+            extra_properties={"ai_product": "my-app"},
+        )
+        assert ev["properties"]["ai_product"] == "my-app"
 
     def test_timestamp_passthrough(self):
         ev = build_ai_trace(

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -1,6 +1,5 @@
-"""Tests for the Claude Code session JSONL parser."""
+"""Tests for the Claude Code session JSONL parser and event builder."""
 
-import importlib.util
 import json
 import os
 import sys
@@ -8,21 +7,13 @@ import tempfile
 
 import pytest
 
-# Load modules
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-import posthog_llma  # noqa: E402
+# Add plugin root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-_spec = importlib.util.spec_from_file_location(
-    "session_end_llma",
-    os.path.join(os.path.dirname(__file__), "..", "hooks", "session-end-llma.py"),
-)
-_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_mod)
-parse_session = _mod.parse_session
-build_events = _mod.build_events
-load_config = _mod.load_config
-_find_trace_name = _mod._find_trace_name
-_clean_trace_name = _mod._clean_trace_name
+from posthog_llma.parser import parse_session
+from posthog_llma.event_builder import build_events
+from posthog_llma.config import load_config
+from posthog_llma.trace_naming import find_trace_name, clean_trace_name
 
 DEFAULT_CONFIG = {"privacy_mode": False, "max_attribute_length": 12000, "trace_grouping": "session"}
 
@@ -37,12 +28,7 @@ def _write_jsonl(entries: list[dict]) -> str:
 
 
 def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
-    """Build a minimal but realistic session JSONL.
-
-    prompts_and_tools: list of dicts with keys:
-        - prompt: str (user prompt text)
-        - tools: list of str (tool names to call), optional
-    """
+    """Build a minimal but realistic session JSONL."""
     if prompts_and_tools is None:
         prompts_and_tools = [
             {"prompt": "hello", "tools": []},
@@ -50,7 +36,6 @@ def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
         ]
 
     entries = []
-    # Permission mode entry
     entries.append({
         "type": "permission-mode",
         "permissionMode": "default",
@@ -62,7 +47,6 @@ def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
         prompt_id = f"prompt-{i}"
         user_uuid = f"user-uuid-{i}"
 
-        # User prompt
         entries.append({
             "type": "user",
             "uuid": user_uuid,
@@ -79,46 +63,38 @@ def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
 
         tools = pt.get("tools", [])
         if tools:
-            # Assistant message with tool_use (first entry: no tool blocks)
             msg_id = f"msg-{msg_counter}"
             asst_uuid = f"asst-uuid-{msg_counter}"
             msg_counter += 1
+            # First entry: no tool blocks (streaming)
             entries.append({
                 "type": "assistant",
                 "uuid": asst_uuid,
                 "parentUuid": user_uuid,
                 "message": {
-                    "role": "assistant",
-                    "id": msg_id,
-                    "model": "claude-opus-4-6",
-                    "stop_reason": "tool_use",
+                    "role": "assistant", "id": msg_id,
+                    "model": "claude-opus-4-6", "stop_reason": "tool_use",
                     "usage": {"input_tokens": 10, "output_tokens": 80, "cache_read_input_tokens": 5, "cache_creation_input_tokens": 0},
                     "content": [],
                 },
                 "timestamp": f"2026-04-12T10:0{i}:01.000Z",
-                "sessionId": "test-session-id",
-                "version": "2.1.0",
-                "cwd": "/Users/test/myproject",
+                "sessionId": "test-session-id", "version": "2.1.0", "cwd": "/Users/test/myproject",
             })
-            # Assistant message with tool_use (second entry: has tool blocks — streaming dedup)
+            # Second entry: has tool blocks (complete)
             entries.append({
                 "type": "assistant",
                 "uuid": asst_uuid,
                 "parentUuid": user_uuid,
                 "message": {
-                    "role": "assistant",
-                    "id": msg_id,
-                    "model": "claude-opus-4-6",
-                    "stop_reason": "tool_use",
+                    "role": "assistant", "id": msg_id,
+                    "model": "claude-opus-4-6", "stop_reason": "tool_use",
                     "usage": {"input_tokens": 10, "output_tokens": 80, "cache_read_input_tokens": 5, "cache_creation_input_tokens": 0},
                     "content": [
                         {"type": "tool_use", "id": f"tool-{msg_id}", "name": tools[0], "input": {"command": "ls"}},
                     ],
                 },
                 "timestamp": f"2026-04-12T10:0{i}:01.000Z",
-                "sessionId": "test-session-id",
-                "version": "2.1.0",
-                "cwd": "/Users/test/myproject",
+                "sessionId": "test-session-id", "version": "2.1.0", "cwd": "/Users/test/myproject",
             })
             # Tool result
             entries.append({
@@ -133,11 +109,9 @@ def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
                     ],
                 },
                 "timestamp": f"2026-04-12T10:0{i}:02.000Z",
-                "sessionId": "test-session-id",
-                "version": "2.1.0",
-                "cwd": "/Users/test/myproject",
+                "sessionId": "test-session-id", "version": "2.1.0", "cwd": "/Users/test/myproject",
             })
-            # Follow-up assistant message (stop)
+            # Follow-up response
             msg_id2 = f"msg-{msg_counter}"
             msg_counter += 1
             entries.append({
@@ -145,20 +119,15 @@ def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
                 "uuid": f"asst-uuid-{msg_counter}",
                 "parentUuid": asst_uuid,
                 "message": {
-                    "role": "assistant",
-                    "id": msg_id2,
-                    "model": "claude-opus-4-6",
-                    "stop_reason": "end_turn",
+                    "role": "assistant", "id": msg_id2,
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
                     "usage": {"input_tokens": 10, "output_tokens": 30, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
                     "content": [{"type": "text", "text": "Done!"}],
                 },
                 "timestamp": f"2026-04-12T10:0{i}:03.000Z",
-                "sessionId": "test-session-id",
-                "version": "2.1.0",
-                "cwd": "/Users/test/myproject",
+                "sessionId": "test-session-id", "version": "2.1.0", "cwd": "/Users/test/myproject",
             })
         else:
-            # Simple assistant response (no tools)
             msg_id = f"msg-{msg_counter}"
             msg_counter += 1
             entries.append({
@@ -166,17 +135,13 @@ def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
                 "uuid": f"asst-uuid-{msg_counter}",
                 "parentUuid": user_uuid,
                 "message": {
-                    "role": "assistant",
-                    "id": msg_id,
-                    "model": "claude-opus-4-6",
-                    "stop_reason": "end_turn",
+                    "role": "assistant", "id": msg_id,
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
                     "usage": {"input_tokens": 10, "output_tokens": 40, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
                     "content": [{"type": "text", "text": "Hello!"}],
                 },
                 "timestamp": f"2026-04-12T10:0{i}:01.000Z",
-                "sessionId": "test-session-id",
-                "version": "2.1.0",
-                "cwd": "/Users/test/myproject",
+                "sessionId": "test-session-id", "version": "2.1.0", "cwd": "/Users/test/myproject",
             })
 
     return entries
@@ -200,11 +165,9 @@ class TestParseSession:
             os.unlink(path)
 
     def test_dedup_keeps_last_entry(self):
-        """Later streaming entries have tool_use blocks, earlier ones don't."""
         path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
         try:
             parsed = parse_session(path, DEFAULT_CONFIG)
-            # Should have 2 generations (tool_use + follow-up), not 3 (no dupe)
             assert len(parsed["generations"]) == 2
             assert len(parsed["tool_uses"]) == 1
             assert parsed["tool_uses"][0]["name"] == "Bash"
@@ -240,22 +203,16 @@ class TestParseSession:
             os.unlink(path)
 
     def test_slash_command_without_prompt_id(self):
-        """Slash commands lack promptId but should still be captured."""
         entries = [
             {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
             {
-                "type": "user",
-                "uuid": "cmd-uuid",
-                "parentUuid": None,
-                "isMeta": False,
+                "type": "user", "uuid": "cmd-uuid", "parentUuid": None, "isMeta": False,
                 "message": {"role": "user", "content": "<command-message>posthog:llma-cc-status</command-message>"},
                 "timestamp": "2026-04-12T10:00:00.000Z",
                 "sessionId": "s1", "version": "2.1.0", "cwd": "/test",
             },
             {
-                "type": "assistant",
-                "uuid": "asst-uuid",
-                "parentUuid": "cmd-uuid",
+                "type": "assistant", "uuid": "asst-uuid", "parentUuid": "cmd-uuid",
                 "message": {
                     "role": "assistant", "id": "msg-1", "model": "claude-opus-4-6",
                     "stop_reason": "end_turn",
@@ -290,7 +247,6 @@ class TestBuildEvents:
             traces = [e for e in events if e["event"] == "$ai_trace"]
             gens = [e for e in events if e["event"] == "$ai_generation"]
             assert len(traces) == 1
-            # All generations share the session trace_id
             trace_ids = set(e["properties"]["$ai_trace_id"] for e in gens)
             assert len(trace_ids) == 1
             assert trace_ids.pop() == "test-session-id"
@@ -304,12 +260,11 @@ class TestBuildEvents:
             parsed = parse_session(path, config)
             events = build_events(parsed, config)
             traces = [e for e in events if e["event"] == "$ai_trace"]
-            assert len(traces) == 2  # one per prompt
+            assert len(traces) == 2
         finally:
             os.unlink(path)
 
     def test_tool_use_blocks_in_output_choices(self):
-        """Output choices should include tool_use blocks for PostHog tool extraction."""
         path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
         try:
             parsed = parse_session(path, DEFAULT_CONFIG)
@@ -344,7 +299,6 @@ class TestBuildEvents:
             events = build_events(parsed, DEFAULT_CONFIG)
             span = next(e for e in events if e["event"] == "$ai_span")
             assert span["properties"]["$ai_parent_id"] is not None
-            # Parent should be one of the generation span_ids
             gen_span_ids = {e["properties"]["$ai_span_id"] for e in events if e["event"] == "$ai_generation"}
             assert span["properties"]["$ai_parent_id"] in gen_span_ids
         finally:
@@ -363,47 +317,38 @@ class TestBuildEvents:
 
 
 # ---------------------------------------------------------------------------
-# _clean_trace_name / _find_trace_name
+# trace naming
 # ---------------------------------------------------------------------------
 
 
 class TestTraceNaming:
     def test_clean_strips_tags(self):
-        assert _clean_trace_name("<command-name>/clear</command-name>") == "/clear"
+        assert clean_trace_name("<command-name>/clear</command-name>") == "/clear"
 
     def test_clean_collapses_whitespace(self):
-        assert _clean_trace_name("  hello   world  ") == "hello world"
+        assert clean_trace_name("  hello   world  ") == "hello world"
 
     def test_clean_truncates(self):
-        assert len(_clean_trace_name("x" * 200, max_len=50)) == 50
+        assert len(clean_trace_name("x" * 200, max_len=50)) == 50
 
     def test_find_skips_clear(self):
-        prompts = [
-            {"text": "/clear"},
-            {"text": "help me fix a bug"},
-        ]
-        assert _find_trace_name(prompts) == "help me fix a bug"
+        prompts = [{"text": "/clear"}, {"text": "help me fix a bug"}]
+        assert find_trace_name(prompts) == "help me fix a bug"
 
     def test_find_skips_exit(self):
-        prompts = [
-            {"text": "/exit"},
-            {"text": "real question"},
-        ]
-        assert _find_trace_name(prompts) == "real question"
+        prompts = [{"text": "/exit"}, {"text": "real question"}]
+        assert find_trace_name(prompts) == "real question"
 
     def test_find_skips_interrupted(self):
-        prompts = [
-            {"text": "[Request interrupted by user]"},
-            {"text": "actual task"},
-        ]
-        assert _find_trace_name(prompts) == "actual task"
+        prompts = [{"text": "[Request interrupted by user]"}, {"text": "actual task"}]
+        assert find_trace_name(prompts) == "actual task"
 
     def test_find_falls_back_to_first(self):
         prompts = [{"text": "/clear"}]
-        assert _find_trace_name(prompts) == "/clear"
+        assert find_trace_name(prompts) == "/clear"
 
     def test_find_returns_none_for_empty(self):
-        assert _find_trace_name([]) is None
+        assert find_trace_name([]) is None
 
 
 # ---------------------------------------------------------------------------
@@ -413,14 +358,14 @@ class TestTraceNaming:
 
 class TestLoadConfig:
     def test_disabled_by_default(self):
-        """POSTHOG_LLMA_CC_ENABLED must be explicitly set to true."""
-        env = {k: v for k, v in os.environ.items()}
+        env = dict(os.environ)
         os.environ.pop("POSTHOG_LLMA_CC_ENABLED", None)
         os.environ.pop("POSTHOG_API_KEY", None)
         try:
             config = load_config()
             assert config["enabled"] is False
         finally:
+            os.environ.clear()
             os.environ.update(env)
 
     def test_enabled_when_set(self):

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -27,7 +27,7 @@ def _write_jsonl(entries: list[dict]) -> str:
     return f.name
 
 
-def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
+def _make_session(prompts_and_tools=None) -> list[dict]:
     """Build a minimal but realistic session JSONL."""
     if prompts_and_tools is None:
         prompts_and_tools = [
@@ -304,6 +304,18 @@ class TestBuildEvents:
         finally:
             os.unlink(path)
 
+    def test_custom_properties_on_all_events(self):
+        config = {**DEFAULT_CONFIG, "custom_properties": {"ai_product": "test-app"}}
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, config)
+            events = build_events(parsed, config)
+            for e in events:
+                assert e["properties"].get("ai_product") == "test-app", \
+                    f"{e['event']} missing custom property"
+        finally:
+            os.unlink(path)
+
     def test_timestamps_are_real(self):
         path = _write_jsonl(_make_session())
         try:
@@ -357,10 +369,15 @@ class TestTraceNaming:
 
 
 class TestLoadConfig:
+    def _clean_env(self):
+        """Remove all POSTHOG_ env vars."""
+        for k in list(os.environ):
+            if k.startswith("POSTHOG_"):
+                del os.environ[k]
+
     def test_disabled_by_default(self):
         env = dict(os.environ)
-        os.environ.pop("POSTHOG_LLMA_CC_ENABLED", None)
-        os.environ.pop("POSTHOG_API_KEY", None)
+        self._clean_env()
         try:
             config = load_config()
             assert config["enabled"] is False
@@ -369,6 +386,8 @@ class TestLoadConfig:
             os.environ.update(env)
 
     def test_enabled_when_set(self):
+        env = dict(os.environ)
+        self._clean_env()
         os.environ["POSTHOG_LLMA_CC_ENABLED"] = "true"
         os.environ["POSTHOG_API_KEY"] = "phc_test"
         try:
@@ -376,5 +395,37 @@ class TestLoadConfig:
             assert config["enabled"] is True
             assert config["api_key"] == "phc_test"
         finally:
-            os.environ.pop("POSTHOG_LLMA_CC_ENABLED", None)
-            os.environ.pop("POSTHOG_API_KEY", None)
+            os.environ.clear()
+            os.environ.update(env)
+
+    def test_custom_properties_parsed(self):
+        env = dict(os.environ)
+        self._clean_env()
+        os.environ["POSTHOG_LLMA_CUSTOM_PROPERTIES"] = '{"ai_product": "my-app", "team": "platform"}'
+        try:
+            config = load_config()
+            assert config["custom_properties"] == {"ai_product": "my-app", "team": "platform"}
+        finally:
+            os.environ.clear()
+            os.environ.update(env)
+
+    def test_custom_properties_invalid_json_ignored(self):
+        env = dict(os.environ)
+        self._clean_env()
+        os.environ["POSTHOG_LLMA_CUSTOM_PROPERTIES"] = "not json"
+        try:
+            config = load_config()
+            assert config["custom_properties"] == {}
+        finally:
+            os.environ.clear()
+            os.environ.update(env)
+
+    def test_custom_properties_empty_by_default(self):
+        env = dict(os.environ)
+        self._clean_env()
+        try:
+            config = load_config()
+            assert config["custom_properties"] == {}
+        finally:
+            os.environ.clear()
+            os.environ.update(env)

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -1,0 +1,435 @@
+"""Tests for the Claude Code session JSONL parser."""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+# Load modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import posthog_llma  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "session_end_llma",
+    os.path.join(os.path.dirname(__file__), "..", "hooks", "session-end-llma.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+parse_session = _mod.parse_session
+build_events = _mod.build_events
+load_config = _mod.load_config
+_find_trace_name = _mod._find_trace_name
+_clean_trace_name = _mod._clean_trace_name
+
+DEFAULT_CONFIG = {"privacy_mode": False, "max_attribute_length": 12000, "trace_grouping": "session"}
+
+
+def _write_jsonl(entries: list[dict]) -> str:
+    """Write entries to a temp JSONL file and return the path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
+    for entry in entries:
+        f.write(json.dumps(entry) + "\n")
+    f.close()
+    return f.name
+
+
+def _make_session(prompts_and_tools: list[dict] | None = None) -> list[dict]:
+    """Build a minimal but realistic session JSONL.
+
+    prompts_and_tools: list of dicts with keys:
+        - prompt: str (user prompt text)
+        - tools: list of str (tool names to call), optional
+    """
+    if prompts_and_tools is None:
+        prompts_and_tools = [
+            {"prompt": "hello", "tools": []},
+            {"prompt": "run ls", "tools": ["Bash"]},
+        ]
+
+    entries = []
+    # Permission mode entry
+    entries.append({
+        "type": "permission-mode",
+        "permissionMode": "default",
+        "sessionId": "test-session-id",
+    })
+
+    msg_counter = 0
+    for i, pt in enumerate(prompts_and_tools):
+        prompt_id = f"prompt-{i}"
+        user_uuid = f"user-uuid-{i}"
+
+        # User prompt
+        entries.append({
+            "type": "user",
+            "uuid": user_uuid,
+            "parentUuid": None,
+            "promptId": prompt_id,
+            "isMeta": False,
+            "message": {"role": "user", "content": pt["prompt"]},
+            "timestamp": f"2026-04-12T10:0{i}:00.000Z",
+            "sessionId": "test-session-id",
+            "version": "2.1.0",
+            "cwd": "/Users/test/myproject",
+            "gitBranch": "main",
+        })
+
+        tools = pt.get("tools", [])
+        if tools:
+            # Assistant message with tool_use (first entry: no tool blocks)
+            msg_id = f"msg-{msg_counter}"
+            asst_uuid = f"asst-uuid-{msg_counter}"
+            msg_counter += 1
+            entries.append({
+                "type": "assistant",
+                "uuid": asst_uuid,
+                "parentUuid": user_uuid,
+                "message": {
+                    "role": "assistant",
+                    "id": msg_id,
+                    "model": "claude-opus-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 10, "output_tokens": 80, "cache_read_input_tokens": 5, "cache_creation_input_tokens": 0},
+                    "content": [],
+                },
+                "timestamp": f"2026-04-12T10:0{i}:01.000Z",
+                "sessionId": "test-session-id",
+                "version": "2.1.0",
+                "cwd": "/Users/test/myproject",
+            })
+            # Assistant message with tool_use (second entry: has tool blocks — streaming dedup)
+            entries.append({
+                "type": "assistant",
+                "uuid": asst_uuid,
+                "parentUuid": user_uuid,
+                "message": {
+                    "role": "assistant",
+                    "id": msg_id,
+                    "model": "claude-opus-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 10, "output_tokens": 80, "cache_read_input_tokens": 5, "cache_creation_input_tokens": 0},
+                    "content": [
+                        {"type": "tool_use", "id": f"tool-{msg_id}", "name": tools[0], "input": {"command": "ls"}},
+                    ],
+                },
+                "timestamp": f"2026-04-12T10:0{i}:01.000Z",
+                "sessionId": "test-session-id",
+                "version": "2.1.0",
+                "cwd": "/Users/test/myproject",
+            })
+            # Tool result
+            entries.append({
+                "type": "user",
+                "uuid": f"result-uuid-{msg_counter}",
+                "parentUuid": asst_uuid,
+                "isMeta": False,
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": f"tool-{msg_id}", "content": "tool output here", "is_error": False},
+                    ],
+                },
+                "timestamp": f"2026-04-12T10:0{i}:02.000Z",
+                "sessionId": "test-session-id",
+                "version": "2.1.0",
+                "cwd": "/Users/test/myproject",
+            })
+            # Follow-up assistant message (stop)
+            msg_id2 = f"msg-{msg_counter}"
+            msg_counter += 1
+            entries.append({
+                "type": "assistant",
+                "uuid": f"asst-uuid-{msg_counter}",
+                "parentUuid": asst_uuid,
+                "message": {
+                    "role": "assistant",
+                    "id": msg_id2,
+                    "model": "claude-opus-4-6",
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 10, "output_tokens": 30, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                    "content": [{"type": "text", "text": "Done!"}],
+                },
+                "timestamp": f"2026-04-12T10:0{i}:03.000Z",
+                "sessionId": "test-session-id",
+                "version": "2.1.0",
+                "cwd": "/Users/test/myproject",
+            })
+        else:
+            # Simple assistant response (no tools)
+            msg_id = f"msg-{msg_counter}"
+            msg_counter += 1
+            entries.append({
+                "type": "assistant",
+                "uuid": f"asst-uuid-{msg_counter}",
+                "parentUuid": user_uuid,
+                "message": {
+                    "role": "assistant",
+                    "id": msg_id,
+                    "model": "claude-opus-4-6",
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 10, "output_tokens": 40, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                    "content": [{"type": "text", "text": "Hello!"}],
+                },
+                "timestamp": f"2026-04-12T10:0{i}:01.000Z",
+                "sessionId": "test-session-id",
+                "version": "2.1.0",
+                "cwd": "/Users/test/myproject",
+            })
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# parse_session
+# ---------------------------------------------------------------------------
+
+
+class TestParseSession:
+    def test_basic_parsing(self):
+        path = _write_jsonl(_make_session())
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert parsed["session_id"] == "test-session-id"
+            assert len(parsed["prompts"]) == 2
+            assert parsed["prompts"][0]["text"] == "hello"
+            assert parsed["prompts"][1]["text"] == "run ls"
+        finally:
+            os.unlink(path)
+
+    def test_dedup_keeps_last_entry(self):
+        """Later streaming entries have tool_use blocks, earlier ones don't."""
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            # Should have 2 generations (tool_use + follow-up), not 3 (no dupe)
+            assert len(parsed["generations"]) == 2
+            assert len(parsed["tool_uses"]) == 1
+            assert parsed["tool_uses"][0]["name"] == "Bash"
+        finally:
+            os.unlink(path)
+
+    def test_tool_result_matching(self):
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            tu = parsed["tool_uses"][0]
+            assert "result" in tu
+            assert tu["result"]["content"] == "tool output here"
+        finally:
+            os.unlink(path)
+
+    def test_prompt_id_resolution_via_parent_chain(self):
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            for gen in parsed["generations"]:
+                assert gen["prompt_id"] == "prompt-0"
+        finally:
+            os.unlink(path)
+
+    def test_privacy_mode_redacts_prompts(self):
+        config = {**DEFAULT_CONFIG, "privacy_mode": True}
+        path = _write_jsonl(_make_session([{"prompt": "secret stuff", "tools": []}]))
+        try:
+            parsed = parse_session(path, config)
+            assert parsed["prompts"][0]["text"] is None
+        finally:
+            os.unlink(path)
+
+    def test_slash_command_without_prompt_id(self):
+        """Slash commands lack promptId but should still be captured."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user",
+                "uuid": "cmd-uuid",
+                "parentUuid": None,
+                "isMeta": False,
+                "message": {"role": "user", "content": "<command-message>posthog:llma-cc-status</command-message>"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/test",
+            },
+            {
+                "type": "assistant",
+                "uuid": "asst-uuid",
+                "parentUuid": "cmd-uuid",
+                "message": {
+                    "role": "assistant", "id": "msg-1", "model": "claude-opus-4-6",
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 20, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                    "content": [{"type": "text", "text": "Status: ok"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/test",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert len(parsed["prompts"]) == 1
+            assert len(parsed["generations"]) == 1
+            assert parsed["generations"][0]["prompt_id"] != ""
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# build_events
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEvents:
+    def test_session_trace_grouping(self):
+        path = _write_jsonl(_make_session())
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            traces = [e for e in events if e["event"] == "$ai_trace"]
+            gens = [e for e in events if e["event"] == "$ai_generation"]
+            assert len(traces) == 1
+            # All generations share the session trace_id
+            trace_ids = set(e["properties"]["$ai_trace_id"] for e in gens)
+            assert len(trace_ids) == 1
+            assert trace_ids.pop() == "test-session-id"
+        finally:
+            os.unlink(path)
+
+    def test_message_trace_grouping(self):
+        config = {**DEFAULT_CONFIG, "trace_grouping": "message"}
+        path = _write_jsonl(_make_session())
+        try:
+            parsed = parse_session(path, config)
+            events = build_events(parsed, config)
+            traces = [e for e in events if e["event"] == "$ai_trace"]
+            assert len(traces) == 2  # one per prompt
+        finally:
+            os.unlink(path)
+
+    def test_tool_use_blocks_in_output_choices(self):
+        """Output choices should include tool_use blocks for PostHog tool extraction."""
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            tool_gen = next(
+                e for e in events
+                if e["event"] == "$ai_generation" and e["properties"]["$ai_stop_reason"] == "tool_calls"
+            )
+            oc = tool_gen["properties"]["$ai_output_choices"]
+            assert oc is not None
+            content = oc[0]["content"]
+            tool_blocks = [b for b in content if b.get("type") == "tool_use"]
+            assert len(tool_blocks) == 1
+            assert tool_blocks[0]["name"] == "Bash"
+        finally:
+            os.unlink(path)
+
+    def test_input_messages_set(self):
+        path = _write_jsonl(_make_session([{"prompt": "hello there", "tools": []}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            gen = next(e for e in events if e["event"] == "$ai_generation")
+            assert gen["properties"]["$ai_input"] == [{"role": "user", "content": "hello there"}]
+        finally:
+            os.unlink(path)
+
+    def test_span_has_parent_id(self):
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            span = next(e for e in events if e["event"] == "$ai_span")
+            assert span["properties"]["$ai_parent_id"] is not None
+            # Parent should be one of the generation span_ids
+            gen_span_ids = {e["properties"]["$ai_span_id"] for e in events if e["event"] == "$ai_generation"}
+            assert span["properties"]["$ai_parent_id"] in gen_span_ids
+        finally:
+            os.unlink(path)
+
+    def test_timestamps_are_real(self):
+        path = _write_jsonl(_make_session())
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            for e in events:
+                if "timestamp" in e:
+                    assert e["timestamp"].startswith("2026-04-12T10:")
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# _clean_trace_name / _find_trace_name
+# ---------------------------------------------------------------------------
+
+
+class TestTraceNaming:
+    def test_clean_strips_tags(self):
+        assert _clean_trace_name("<command-name>/clear</command-name>") == "/clear"
+
+    def test_clean_collapses_whitespace(self):
+        assert _clean_trace_name("  hello   world  ") == "hello world"
+
+    def test_clean_truncates(self):
+        assert len(_clean_trace_name("x" * 200, max_len=50)) == 50
+
+    def test_find_skips_clear(self):
+        prompts = [
+            {"text": "/clear"},
+            {"text": "help me fix a bug"},
+        ]
+        assert _find_trace_name(prompts) == "help me fix a bug"
+
+    def test_find_skips_exit(self):
+        prompts = [
+            {"text": "/exit"},
+            {"text": "real question"},
+        ]
+        assert _find_trace_name(prompts) == "real question"
+
+    def test_find_skips_interrupted(self):
+        prompts = [
+            {"text": "[Request interrupted by user]"},
+            {"text": "actual task"},
+        ]
+        assert _find_trace_name(prompts) == "actual task"
+
+    def test_find_falls_back_to_first(self):
+        prompts = [{"text": "/clear"}]
+        assert _find_trace_name(prompts) == "/clear"
+
+    def test_find_returns_none_for_empty(self):
+        assert _find_trace_name([]) is None
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_disabled_by_default(self):
+        """POSTHOG_LLMA_CC_ENABLED must be explicitly set to true."""
+        env = {k: v for k, v in os.environ.items()}
+        os.environ.pop("POSTHOG_LLMA_CC_ENABLED", None)
+        os.environ.pop("POSTHOG_API_KEY", None)
+        try:
+            config = load_config()
+            assert config["enabled"] is False
+        finally:
+            os.environ.update(env)
+
+    def test_enabled_when_set(self):
+        os.environ["POSTHOG_LLMA_CC_ENABLED"] = "true"
+        os.environ["POSTHOG_API_KEY"] = "phc_test"
+        try:
+            config = load_config()
+            assert config["enabled"] is True
+            assert config["api_key"] == "phc_test"
+        finally:
+            os.environ.pop("POSTHOG_LLMA_CC_ENABLED", None)
+            os.environ.pop("POSTHOG_API_KEY", None)


### PR DESCRIPTION
## Summary

- Adds a SessionEnd hook that parses Claude Code session JSONL logs and sends `$ai_generation`, `$ai_span`, and `$ai_trace` events to PostHog LLM Analytics
- Requires explicit opt-in via `POSTHOG_LLMA_CC_ENABLED=true` plus `POSTHOG_API_KEY` -- existing users are unaffected
- Costs and `$ai_tools_called` are calculated by PostHog's ingestion pipeline automatically
- Supports session-level (default) or per-message trace grouping via `POSTHOG_LLMA_TRACE_GROUPING`
- Supports custom properties on all events via `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON object)
- Zero dependencies -- Python stdlib only

## Package structure

```
posthog_llma/              # reusable Python package
  events.py                # $ai_* event builders
  sender.py                # batch sender + status file
  config.py                # env var / config file loading
  parser.py                # Claude Code JSONL session parser
  event_builder.py         # parsed session -> PostHog events
  trace_naming.py          # trace name selection from prompts
hooks/
  hooks.json               # SessionEnd hook registration
  session-end-llma.py      # thin entry point
scripts/
  llma_cc_ingest.py        # manual session ingestion CLI
commands/
  llma-cc-setup.md         # /posthog:llma-cc-setup
  llma-cc-status.md        # /posthog:llma-cc-status
  llma-cc-ingest.md        # /posthog:llma-cc-ingest
tests/
  test_posthog_llma.py     # event builder tests
  test_session_parser.py   # parser + integration tests
```

## User experience

```bash
# Already doing this
claude plugin install posthog

# Enable LLM analytics -- requires explicit opt-in
export POSTHOG_LLMA_CC_ENABLED=true
export POSTHOG_API_KEY="phc_..."
export POSTHOG_HOST="https://eu.i.posthog.com"  # optional, defaults to US

# Optional: tag all events with custom properties
export POSTHOG_LLMA_CUSTOM_PROPERTIES='{"ai_product": "my-app", "team": "platform"}'
```

## Bug fixes

- **Python 3.9 compat**: replaced PEP 604 `X | None` with `Optional[X]` so entrypoints work on stock macOS `python3` (3.9.6) instead of requiring 3.10+
- **`$ai_parent_id` on generations**: `$ai_generation` events now set `$ai_parent_id` linking them to their trace root in PostHog's span hierarchy
- **Fallback trace roots**: in message grouping mode, generations with unresolved `prompt_id` now get a root `$ai_trace` event instead of being orphaned

## Test plan

- [x] Tested end-to-end: session JSONL parsed, events sent to PostHog dev instance
- [x] Verified `$ai_generation` events with model, tokens, cost (auto-enriched by PostHog)
- [x] Verified `$ai_generation` events include `$ai_parent_id` pointing at trace root
- [x] Verified `$ai_span` events for tool calls with parent-child linking
- [x] Verified `$ai_trace` events with session-level grouping and trace name from first meaningful prompt
- [x] Verified fallback trace IDs get root `$ai_trace` events in message grouping mode
- [x] Verified `$ai_tools_called` auto-extracted by PostHog from output_choices tool_use blocks
- [x] Verified timestamps are real (from session log) and correctly ordered
- [x] Verified no-op when `POSTHOG_LLMA_CC_ENABLED` is not set to true
- [x] Verified privacy mode redacts prompt/output content
- [x] Verified custom properties appear on all event types ($ai_generation, $ai_span, $ai_trace)
- [x] Verified dedup handles streaming duplicate entries in session logs
- [x] Verified manual ingestion via `/posthog:llma-cc-ingest`
- [x] Verified imports succeed on `/usr/bin/python3` (macOS 3.9.6)
- [x] 51 pytest tests passing