### PR TITLE
feat: use PostHog MCP projects-get to auto-retrieve API key in instrument skills

### DIFF
--- a/skills/instrument-error-tracking/SKILL.md
+++ b/skills/instrument-error-tracking/SKILL.md
@@ -47,7 +47,10 @@ STEP 6: Upload source maps (frontend/mobile only).
   - Follow the platform-specific reference for upload configuration (build plugins, CI scripts, etc.).
 
 STEP 7: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys to see which keys already exist, then use set_env_values to create or update the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 STEP 8: Verify and clean up.

--- a/skills/instrument-feature-flags/SKILL.md
+++ b/skills/instrument-feature-flags/SKILL.md
@@ -42,7 +42,10 @@ STEP 5: Instrument the feature.
   - You must read a file immediately before attempting to write it.
 
 STEP 6: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys to see which keys already exist, then use set_env_values to create or update the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 ## Reference files

--- a/skills/instrument-integration/SKILL.md
+++ b/skills/instrument-integration/SKILL.md
@@ -40,7 +40,10 @@ STEP 5: Identify users.
   - If both frontend and backend exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to the server-side code.
 
 STEP 6: Set up environment variables.
-  - Store the PostHog API key and host in environment variables (e.g. `.env` or framework-specific env files).
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file (e.g. `.env.local` for Next.js, `.env` for others) using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 STEP 7: Verify and clean up.

--- a/skills/instrument-llm-analytics/SKILL.md
+++ b/skills/instrument-llm-analytics/SKILL.md
@@ -47,7 +47,10 @@ STEP 5: Link to users.
   - Associate LLM generations with identified users via distinct IDs when possible.
 
 STEP 6: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys then set_env_values to configure the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 ## Reference files

--- a/skills/instrument-logs/SKILL.md
+++ b/skills/instrument-logs/SKILL.md
@@ -48,7 +48,11 @@ STEP 6: Add structured properties.
   - Prefer structured log formats with key-value properties over plain text messages.
 
 STEP 7: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys then set_env_values to configure the PostHog API key, host, and OpenTelemetry endpoint.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - For the OpenTelemetry endpoint, use `https://us.i.posthog.com/v1` (US) or `https://eu.i.posthog.com/v1` (EU).
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 ## Reference files

--- a/skills/instrument-product-analytics/SKILL.md
+++ b/skills/instrument-product-analytics/SKILL.md
@@ -55,7 +55,10 @@ STEP 8: Add error tracking.
   - Add PostHog exception capture error tracking to relevant files, particularly around critical user flows and API boundaries.
 
 STEP 9: Set up environment variables.
-  - If an env-file-tools MCP server is connected, use check_env_keys to see which keys already exist, then use set_env_values to create or update the PostHog API key and host.
+  - Check if the project already has PostHog environment variables configured (e.g. in `.env`, `.env.local`, or framework-specific env files). If valid values already exist, skip this step.
+  - If the PostHog API key is missing, use the PostHog MCP server's `projects-get` tool to retrieve the project's `api_token`. If multiple projects are returned, ask the user which project to use. If the MCP server is not connected or not authenticated, ask the user for their PostHog project API key instead.
+  - For the PostHog host URL, use `https://us.i.posthog.com` for US Cloud or `https://eu.i.posthog.com` for EU Cloud.
+  - Write these values to the appropriate env file using the framework's naming convention.
   - Reference these environment variables in code instead of hardcoding them.
 
 STEP 10: Verify and clean up.


### PR DESCRIPTION
## Problem

The `instrument-*` skills (integration, product-analytics, feature-flags, error-tracking, llm-analytics, logs) need the user's PostHog project API key and host URL to write into `.env` files when setting up the SDK. Currently they either:

- Ask the user inline ("what's your API key?")
- Write placeholder values
- Reference an `env-file-tools` MCP server that doesn't exist in the plugin context

Meanwhile, the PostHog MCP server is already connected and authenticated via OAuth, and `projects-get` returns the `api_token` for every project.

## Changes

Updated the env var setup step in all 6 `instrument-*` SKILL.md files to:

1. Check if PostHog env vars already exist (skip if so)
2. Call `projects-get` from the PostHog MCP to retrieve the `api_token`
3. Handle multi-project orgs (ask user which project)
4. Gracefully fall back to asking the user if MCP isn't connected/authenticated
5. Default to US/EU Cloud host URLs
6. Write values using framework-specific env var naming conventions

## How did you test this code

- Verified `projects-get` returns `api_token` via the MCP tools
- Confirmed the env-file-tools MCP references were dangling (not available in plugin context)
- Audited all 13 skills to confirm only instrument-* skills are affected
- Checked reference/example files to verify framework-specific env var naming is handled by existing references

## Changelog

No - this is an internal skill improvement, not a user-facing feature.