### PR TITLE
fix(phai): use GitHub App token for checkout in sync-skills

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download skills from PostHog release
         env:


### PR DESCRIPTION
## Problem

The daily sync-skills workflow was failing with `remote: Permission to PostHog/ai-plugin.git denied to github-actions[bot]` on the `git push origin "$BRANCH"` step (see [run 24306417782](https://github.com/PostHog/ai-plugin/actions/runs/24306417782/job/70968316177)).

Commit 68fc96b switched the workflow to a GitHub App token but only wired it into the `ghcommit-action` and `gh` CLI steps. `actions/checkout` still used the default `GITHUB_TOKEN`, so git's persisted credentials belonged to `github-actions[bot]`, which lacks push permission — the manual `git push` inherited those creds and 403'd.

## Changes

- Pass `steps.app-token.outputs.token` to `actions/checkout` so the persisted git credentials use the App identity.

## How did you test this code?

- Static: traced the failing step; the push in "Create sync branch" uses the checkout-persisted credentials, which were `github-actions[bot]`.
- End-to-end verification will happen on the next scheduled run (or via `workflow_dispatch`) after merge.

## Publish to changelog?

no