### PR TITLE
chore(phai): request team review on sync-skills PRs

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -150,5 +150,6 @@ jobs:
             --base "$BASE_REF" \
             --head "$HEAD_REF" \
             --title "$COMMIT_MESSAGE" \
-            --body "Automated skill sync from PostHog release and context-mill.")
+            --body "Automated skill sync from PostHog release and context-mill." \
+            --reviewer "PostHog/team-posthog-ai")
           gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Problem

Automated sync-skills PRs were being created with no reviewer assigned, so they weren't surfacing to the team for awareness.

## Changes

Pass `--reviewer PostHog/team-posthog-ai` to `gh pr create` in the sync-skills workflow.

## How did you test this code?

Workflow change only — will be validated on the next scheduled or manual run.

## Publish to changelog?

no