### PR TITLE
fix: remove shell-style string interpolation from MCP config

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "displayName": "PostHog",
-  "version": "1.0.4",
+  "version": "1.1.2",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Cursor",
   "author": {
     "name": "PostHog",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "posthog": {
       "type": "http",
-      "url": "${POSTHOG_MCP_URL:-https://mcp.posthog.com/mcp}"
+      "url": "https://mcp.posthog.com/mcp"
     }
   }
 }

--- a/mcp.json
+++ b/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "posthog": {
       "type": "http",
-      "url": "${POSTHOG_MCP_URL:-https://mcp.posthog.com/mcp}"
+      "url": "https://mcp.posthog.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Problem

Cursor and automations built on Cursor (like Lovable) don't support shell-style `${VAR:-default}` string interpolation in MCP configs. Cursor only supports `${env:NAME}`, `${userHome}`, `${workspaceFolder}`, etc.

Our `mcp.json` used `${POSTHOG_MCP_URL:-https://mcp.posthog.com/mcp}`, which meant the URL was passed as a literal string instead of resolving to `https://mcp.posthog.com/mcp`. This broke the MCP connection for anyone installing from the Cursor marketplace.

Reported by Lovable via shared Slack channel, flagged by Georgiy.

## Changes

- Hardcode `https://mcp.posthog.com/mcp` in `mcp.json` and `.mcp.json` (removes the `${POSTHOG_MCP_URL:-...}` wrapper)
- Bump `.cursor-plugin/plugin.json` version from `1.0.4` → `1.1.2` to match the Claude plugin
- Self-hosted users can still override the URL via `POSTHOG_MCP_URL` in their local MCP config per the README

## How did you test this?

- Verified the Cursor MCP docs confirm `${VAR:-default}` is not a supported interpolation syntax
- The change is a straightforward URL hardcode — no behavior change for PostHog Cloud users

## Follow-up

After merging, we need to reach out to Cursor to update the marketplace listing (original setup was via email/form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)