### PR TITLE
fix(codex): add Codex marketplace manifest so `codex plugin marketplace add` works

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "posthog",
       "source": {
-        "source": "local",
-        "path": "../.."
+        "source": "url",
+        "url": "https://github.com/PostHog/ai-plugin.git"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "posthog",
+  "interface": {
+    "displayName": "PostHog"
+  },
+  "plugins": [
+    {
+      "name": "posthog",
+      "source": {
+        "source": "local",
+        "path": "../.."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add man
 
 ### Codex
 
-```bash
-codex plugin install posthog
-```
+1. Add the marketplace:
+    ```bash
+    codex plugin marketplace add PostHog/ai-plugin
+    ```
+
+2. Install the plugin from inside Codex:
+    ```
+    codex
+    # Then run /plugins, select PostHog, and install
+    /plugins
+    ```
 
 ### Gemini CLI
 


### PR DESCRIPTION
## Summary

- Add `.agents/plugins/marketplace.json` so the repo can be registered as a Codex marketplace source.
- Fix the README's Codex install instructions — `codex plugin install posthog` is not a real command on current Codex CLI.

## Why

Today, following the README's Codex section fails:

```
$ codex plugin install posthog
error: unrecognized subcommand 'install'
```

The real Codex CLI surface is `codex plugin marketplace {add,upgrade,remove}`. But pointing it at this repo also fails:

```
$ codex plugin marketplace add PostHog/ai-plugin
Error: invalid marketplace file ...: marketplace root does not contain a supported manifest
```

Codex looks for `.agents/plugins/marketplace.json` at the repo root. This PR adds a minimal marketplace that points at the existing `.codex-plugin/plugin.json` (via `source: local`, `path: ../..`), so the single-plugin repo can be added as a marketplace source. After that, users run `/plugins` inside Codex and install **PostHog** from the picker.

## Why `.agents/` and not `.claude-plugin/marketplace.json`

Codex docs list two supported repo-scoped marketplace locations:

- `$REPO_ROOT/.agents/plugins/marketplace.json`
- `$REPO_ROOT/.claude-plugin/marketplace.json`

This repo is intentionally tool-agnostic (Claude, Codex, Cursor, Gemini), so reusing the Claude-branded folder to host a Codex marketplace would be confusing. `.agents/` is the tool-neutral location and is becoming the shared convention, so we adopt that.

## Relationship to `.codex-plugin/plugin.json`

The two files layer, they don't conflict:

| File | Role |
|---|---|
| `.codex-plugin/plugin.json` | The **plugin itself** — version, author, MCP servers, skills path, display metadata. |
| `.agents/plugins/marketplace.json` | The **catalog pointer** — "a plugin called `posthog` exists, find it at this path." |

The marketplace entry points back at the repo root (`"path": "../.."`), so Codex reads the existing plugin manifest for the real details. The marketplace entry is intentionally minimal (no `version`, no `displayName`, no `description`) — those live in `.codex-plugin/plugin.json` and are read through. That means a version bump in the plugin manifest doesn't require a marketplace edit.

## Testing & validation

Verified against Codex CLI 0.124.0 (Linux) and on macOS:

- [x] Before the fix: `codex plugin marketplace add /path/to/ai-plugin` errors with `marketplace root does not contain a supported manifest`.
- [x] After the fix: `codex plugin marketplace add /path/to/ai-plugin` succeeds — `Added marketplace 'posthog' ... Installed marketplace root: ...`.
- [x] End-to-end from this PR branch on macOS:
      ```
      $ codex plugin marketplace add PostHog/ai-plugin --ref fix/codex-marketplace-manifest
      Added marketplace `posthog` from https://github.com/PostHog/ai-plugin.git#fix/codex-marketplace-manifest.
      Installed marketplace root: /Users/<user>/.codex/.tmp/marketplaces/posthog
      ```

## Follow-ups (out of scope)

- Getting PostHog into Codex's **curated marketplace** (the one that ships with Codex and powers the in-app Plugin Directory, currently only `github`, `google-calendar`, `google-drive`) would let users skip the `marketplace add` step entirely. That's a submission to OpenAI, separate from this PR.

## Reviewer test plan

- [ ] `codex plugin marketplace add PostHog/ai-plugin` succeeds (post-merge)
- [ ] Inside Codex, `/plugins` lists **PostHog** under the new marketplace
- [ ] Selecting PostHog installs the plugin and the OAuth flow launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)