### PR TITLE
fix(phai): prune orphan skill dirs in sync workflow

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -78,6 +78,14 @@ jobs:
           } | sort -u > "$MANIFEST"
           rm -f "$cm_manifest"
 
+          # Reconcile: remove any directory not in the new manifest
+          # (catches orphans from past manual edits or partial deletions)
+          for d in skills/*/; do
+            [ -d "$d" ] || continue
+            name=$(basename "$d")
+            grep -qFx "$name" "$MANIFEST" || rm -rf "$d"
+          done
+
       - name: Check for changes and bump version
         id: check
         env:


### PR DESCRIPTION
## Problem

The sync workflow doesn't handle deletions.

## Changes

After rebuilding the manifest, walk `skills/*/` and remove any directory not present in the new manifest. Extraction happens first, so anything actually shipped by the upstream zips ends up in the manifest and survives the prune.

## How did you test this code?

Traced the workflow logic against the four cases (in/out of old manifest × in/out of new zip) and confirmed the reconcile step only removes dirs the new manifest doesn't claim. Also removed the existing `skills/posthog-instrumentation/` orphan locally — git wasn't tracking it (empty dir).

## Publish to changelog?

no