### PR TITLE
feat(phai): attribute MCP traffic from plugins

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Codex",
   "author": {
     "name": "PostHog",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "displayName": "PostHog",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Cursor",
   "author": {
     "name": "PostHog",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "posthog": {
       "type": "http",
-      "url": "https://mcp.posthog.com/mcp"
+      "url": "https://mcp.posthog.com/mcp",
+      "headers": {
+        "x-posthog-mcp-consumer": "plugin"
+      }
     }
   }
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,13 +1,15 @@
 {
   "name": "posthog",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Gemini CLI",
   "mcpServers": {
     "posthog": {
       "command": "npx",
       "args": [
         "mcp-remote@latest",
-        "${POSTHOG_MCP_URL:-https://mcp.posthog.com/mcp}"
+        "${POSTHOG_MCP_URL:-https://mcp.posthog.com/mcp}",
+        "--header",
+        "x-posthog-mcp-consumer:plugin"
       ]
     }
   },

--- a/mcp.json
+++ b/mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "posthog": {
       "type": "http",
-      "url": "https://mcp.posthog.com/mcp"
+      "url": "https://mcp.posthog.com/mcp",
+      "headers": {
+        "x-posthog-mcp-consumer": "plugin"
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

We can't currently distinguish MCP traffic originating from the bundled plugin distributions from other consumers, which makes it hard to measure plugin adoption and usage.

## Changes

- Pass `x-posthog-mcp-consumer: plugin` header to `mcp.posthog.com/mcp` from all plugin variants (Claude Code, Cursor, Codex via `.mcp.json`/`mcp.json`, and Gemini via the `mcp-remote` `--header` flag).
- Bump plugin versions: Claude (`1.1.15` → `1.1.16`), Codex (`1.0.15` → `1.0.16`), Cursor (`1.1.12` → `1.1.13`), Gemini (`1.0.14` → `1.0.15`).

## How did you test this code?

Verified locally that the JSON files parse and the header config matches each tool's expected schema. Server-side attribution can be confirmed once a plugin install hits the MCP endpoint.

## Publish to changelog?

no