### PR TITLE
feat(phai): allowlist MCP exec writes via POSTHOG_MCP_EXEC_GATE_ALLOW

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run gate-exec-write hook tests
+        run: ./tests/test_gate_exec_write.sh
+
+      - name: Install pytest
+        run: python3 -m pip install --user pytest
+
+      - name: Run Python tests
+        run: python3 -m pytest tests/test_session_parser.py tests/test_posthog_llma.py

--- a/hooks/gate-exec-write.sh
+++ b/hooks/gate-exec-write.sh
@@ -11,6 +11,12 @@
 # Read-only PostHog tools and non-`call` exec verbs are left alone — the hook
 # exits 0 so normal permission flow applies.
 #
+# Users can opt specific write tools out of the prompt via
+# `POSTHOG_MCP_EXEC_GATE_ALLOW` — a comma-separated list of bash glob patterns
+# matched against the PostHog tool name. Example:
+#
+#     export POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*,annotation-create"
+#
 # Pure bash; no jq or other third-party tools required. Relies on the fact
 # that PostHog tool names are kebab-case alphanumerics, so a narrow regex on
 # the raw JSON payload is safe.
@@ -45,6 +51,17 @@ write_re='(^|-)(archive|cancel|create|delete|destroy|disable|duplicate|enable|en
 
 shopt -s nocasematch
 if [[ "$posthog_tool" =~ $write_re ]]; then
+    # User-controlled allowlist — skip the prompt for tools matching any glob
+    # in POSTHOG_MCP_EXEC_GATE_ALLOW. Patterns use bash glob syntax (`*`, `?`).
+    if [[ -n "${POSTHOG_MCP_EXEC_GATE_ALLOW:-}" ]]; then
+        IFS=',' read -ra _allow_patterns <<< "$POSTHOG_MCP_EXEC_GATE_ALLOW"
+        for _pat in "${_allow_patterns[@]}"; do
+            _pat="${_pat#"${_pat%%[![:space:]]*}"}"
+            _pat="${_pat%"${_pat##*[![:space:]]}"}"
+            [[ -n "$_pat" && "$posthog_tool" == $_pat ]] && exit 0
+        done
+    fi
+
     # `posthog_tool` is restricted to [a-zA-Z0-9_-]+ by the regex above, so
     # interpolating it into the JSON response is safe — no characters that
     # would need escaping for JSON or printf.

--- a/tests/test_gate_exec_write.sh
+++ b/tests/test_gate_exec_write.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Tests for hooks/gate-exec-write.sh.
+#
+# Plain bash, no dependencies. Run from anywhere:
+#
+#     ./tests/test_gate_exec_write.sh
+#
+# Each case feeds a JSON payload (the same shape Claude Code passes on stdin)
+# to the hook with a controlled environment, then asserts on stdout and exit
+# status. "silent" = empty stdout + exit 0 (normal permission flow);
+# "prompt"  = JSON `permissionDecision: ask` payload + exit 0.
+
+set -u
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HERE/../hooks/gate-exec-write.sh"
+
+pass=0
+fail=0
+
+# Run hook with given input + env and capture stdout. Args:
+#   $1: case name
+#   $2: stdin payload
+#   $3: expected mode — "silent" or "prompt"
+#   $4: when "prompt", the posthog tool name expected in the response
+#   $5+: optional `KEY=VALUE` env overrides for this run
+run_case() {
+    local name="$1" payload="$2" expected="$3" expected_tool="${4:-}"
+    # Drop the fixed slots; whatever remains are KEY=VALUE env overrides.
+    if (( $# >= 4 )); then shift 4; else shift $#; fi
+    local out status
+    out="$(env -i PATH="$PATH" "$@" bash "$HOOK" <<<"$payload")"
+    status=$?
+
+    local ok=1
+    if [[ "$expected" == "silent" ]]; then
+        [[ -z "$out" && $status -eq 0 ]] || ok=0
+    else
+        # Match the actual JSON shape the hook produces, with the tool name
+        # interpolated. Any drift in the response template will fail here.
+        local needle="\"permissionDecision\":\"ask\""
+        local tool_needle="\`${expected_tool}\` modifies PostHog data"
+        [[ $status -eq 0 && "$out" == *"$needle"* && "$out" == *"$tool_needle"* ]] || ok=0
+    fi
+
+    if (( ok )); then
+        pass=$((pass + 1))
+        printf "  ok   %s\n" "$name"
+    else
+        fail=$((fail + 1))
+        printf "  FAIL %s\n       expected=%s status=%d stdout=%q\n" \
+            "$name" "$expected" "$status" "$out"
+    fi
+}
+
+# Helper: payload for an exec `call <tool>` invocation with default tool name.
+exec_call() {
+    local tool="$1" exec_name="${2:-mcp__posthog__exec}"
+    printf '{"tool_name":"%s","tool_input":{"command":"call %s {}"}}' "$exec_name" "$tool"
+}
+
+echo "Running gate-exec-write.sh tests..."
+
+# --- pass-through cases (no prompt regardless of allowlist) ---
+
+run_case "non-exec tool is ignored" \
+    '{"tool_name":"Bash","tool_input":{}}' \
+    silent
+
+run_case "exec subcommand other than call (tools)" \
+    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"tools"}}' \
+    silent
+
+run_case "exec subcommand other than call (search foo)" \
+    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"search foo"}}' \
+    silent
+
+run_case "read-only call (experiment-get) is silent" \
+    "$(exec_call experiment-get)" \
+    silent
+
+run_case "read-only call (insights-list) is silent" \
+    "$(exec_call insights-list)" \
+    silent
+
+run_case "read-only call with allowlist set is still silent" \
+    "$(exec_call experiment-get)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
+
+# --- write cases without allowlist (should prompt) ---
+
+run_case "write call (experiment-update) prompts" \
+    "$(exec_call experiment-update)" \
+    prompt experiment-update
+
+run_case "write call (notebooks-destroy) prompts" \
+    "$(exec_call notebooks-destroy)" \
+    prompt notebooks-destroy
+
+run_case "write call (cdp-functions-delete) prompts" \
+    "$(exec_call cdp-functions-delete)" \
+    prompt cdp-functions-delete
+
+run_case "write call via plugin-prefixed exec name prompts" \
+    "$(exec_call llma-skill-update mcp__posthog_posthog__exec)" \
+    prompt llma-skill-update
+
+run_case "write call with --json flag still extracts tool" \
+    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"call --json experiment-update {\"id\":1}"}}' \
+    prompt experiment-update
+
+run_case "empty POSTHOG_MCP_EXEC_GATE_ALLOW behaves as unset" \
+    "$(exec_call llma-skill-update)" \
+    prompt llma-skill-update \
+    POSTHOG_MCP_EXEC_GATE_ALLOW=""
+
+# --- write cases with allowlist (should be silent on match) ---
+
+run_case "allowlist glob matches (llma-skill-*)" \
+    "$(exec_call llma-skill-update)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
+
+run_case "allowlist glob matches multiple skill writes (file-create)" \
+    "$(exec_call llma-skill-file-create)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
+
+run_case "allowlist exact match" \
+    "$(exec_call annotation-create)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="annotation-create"
+
+run_case "allowlist multi-entry with whitespace" \
+    "$(exec_call llma-skill-update)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW=" annotation-create , llma-skill-update "
+
+run_case "allowlist ? glob matches single char" \
+    "$(exec_call experiment-end)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="experiment-en?"
+
+# --- write cases with non-matching allowlist (should still prompt) ---
+
+run_case "non-matching allowlist still prompts" \
+    "$(exec_call llma-skill-update)" \
+    prompt llma-skill-update \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="annotation-*"
+
+run_case "allowlist does not bypass an unrelated write tool" \
+    "$(exec_call experiment-update)" \
+    prompt experiment-update \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*,annotation-create"
+
+# --- regex word-boundary cases ---
+
+run_case "tool with no write verb stays silent (persons-list)" \
+    "$(exec_call persons-list)" \
+    silent
+
+run_case "embedded substring is not a write verb (e.g. updates-feed)" \
+    "$(exec_call some-updates-feed)" \
+    silent
+
+# --- summary ---
+
+echo
+echo "Passed: $pass  Failed: $fail"
+(( fail == 0 ))


### PR DESCRIPTION
## Summary

- New `POSTHOG_MCP_EXEC_GATE_ALLOW` env var lets users opt specific PostHog write tools out of the PreToolUse prompt — e.g. `export POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"` to allow all skill writes without re-approving each one. Comma-separated bash globs; read-only tools and unmatched writes prompt as before.
- New bash test suite at `tests/test_gate_exec_write.sh` — 21 cases, no dependencies. Covers pass-through (non-exec, non-`call`, read-only), prompt cases (write verbs, plugin-prefixed exec name, `--json` flag), allowlist matches (glob, exact, multi-entry, `?`, whitespace), and word-boundary edge cases.
- New `.github/workflows/tests.yml` runs the bash suite + existing pytest suites on every PR and on push to `main`.
- Bumps `.claude-plugin/plugin.json` to 1.1.17 (Claude-only change, matching the convention used by the original gate PR #42).

## Test plan

- [x] `./tests/test_gate_exec_write.sh` — 21/21 pass
- [x] `pytest tests/test_session_parser.py tests/test_posthog_llma.py` — 51/51 pass
- [ ] CI green on this PR
- [ ] Manually verify in a Claude Code session: `POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"` skips the prompt for `llma-skill-update`, while `experiment-update` still prompts