### PR TITLE
fix(phai): validate POSTHOG_HOST against an allowlist before sending

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
 
     Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. Add custom properties to all events with `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON string, e.g. `'{"ai_product": "my-app"}'`).
 
+    `POSTHOG_HOST` is restricted to `*.posthog.com` and `localhost` by default — this prevents a project-scoped `settings.json` from silently redirecting Claude Code session content (prompts, tool I/O, your API key) to a third-party host. For self-hosted PostHog, set `POSTHOG_LLMA_ALLOW_CUSTOM_HOST=true` alongside your `POSTHOG_HOST`.
+
 ### Cursor
 
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add manually in Cursor Settings > Plugins.

--- a/commands/llma-cc-setup.md
+++ b/commands/llma-cc-setup.md
@@ -24,7 +24,8 @@ Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Set them
 
 ### Optional
 
-- `POSTHOG_HOST` — PostHog instance URL (default: `https://us.i.posthog.com`, use `https://eu.i.posthog.com` for EU)
+- `POSTHOG_HOST` — PostHog instance URL (default: `https://us.i.posthog.com`, use `https://eu.i.posthog.com` for EU). Restricted to `*.posthog.com` and `localhost` unless `POSTHOG_LLMA_ALLOW_CUSTOM_HOST=true`
+- `POSTHOG_LLMA_ALLOW_CUSTOM_HOST` — Set to `true` to allow a self-hosted PostHog instance for `POSTHOG_HOST` (must still use `https://`)
 - `POSTHOG_LLMA_PRIVACY_MODE` — Set to `true` to redact prompt/output content (tokens and costs still captured)
 - `POSTHOG_LLMA_DISTINCT_ID` — Override the distinct_id (default: git user email)
 - `POSTHOG_LLMA_TRACE_GROUPING` — `session` (default) or `message`

--- a/posthog_llma/__init__.py
+++ b/posthog_llma/__init__.py
@@ -6,7 +6,7 @@ hooks/ and scripts/ directories.
 """
 
 from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
-from posthog_llma.sender import DEFAULT_HOST, send_batch, write_status, read_status, STATUS_FILE
+from posthog_llma.sender import DEFAULT_HOST, send_batch, validate_host, write_status, read_status, STATUS_FILE
 from posthog_llma.config import load_config
 from posthog_llma.parser import parse_session, find_session_log
 from posthog_llma.trace_naming import find_trace_name, clean_trace_name
@@ -17,6 +17,7 @@ __all__ = [
     "build_ai_span",
     "build_ai_trace",
     "send_batch",
+    "validate_host",
     "write_status",
     "read_status",
     "STATUS_FILE",

--- a/posthog_llma/sender.py
+++ b/posthog_llma/sender.py
@@ -6,9 +6,60 @@ import urllib.request
 import urllib.error
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import urlparse
 
 DEFAULT_HOST = "https://us.i.posthog.com"
 STATUS_FILE = os.path.expanduser("~/.claude/posthog-llma-status.json")
+
+# Hostname suffixes treated as known PostHog endpoints. Leading dot enforces
+# a domain-component boundary so `evilposthog.com` is not accepted.
+_POSTHOG_HOST_SUFFIXES = (".posthog.com",)
+_LOCALHOST_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def validate_host(host: str) -> tuple[bool, str]:
+    """Check whether ``host`` is safe to POST telemetry to.
+
+    The telemetry payload contains prompts, tool I/O, and the PostHog API
+    key. Without this check, a project-scoped ``settings.json`` could set
+    ``POSTHOG_HOST`` to an attacker-controlled URL and silently exfiltrate
+    every Claude Code session. We accept:
+
+    - ``https://`` URLs whose hostname ends in ``.posthog.com``
+    - ``http(s)://localhost`` for local development
+    - any host when ``POSTHOG_LLMA_ALLOW_CUSTOM_HOST=true`` (self-hosted opt-in)
+
+    Returns ``(ok, reason)`` where ``reason`` is empty on success.
+    """
+    if not host:
+        return False, "POSTHOG_HOST is empty"
+
+    try:
+        parsed = urlparse(host if "://" in host else f"https://{host}")
+    except ValueError as e:
+        return False, f"POSTHOG_HOST is not a valid URL: {e}"
+
+    scheme = (parsed.scheme or "").lower()
+    hostname = (parsed.hostname or "").lower()
+
+    if not hostname:
+        return False, "POSTHOG_HOST has no hostname"
+    if scheme not in ("https", "http"):
+        return False, f"POSTHOG_HOST scheme must be https (got {scheme!r})"
+    if scheme == "http" and hostname not in _LOCALHOST_HOSTNAMES:
+        return False, "POSTHOG_HOST must use https:// (http:// is only allowed for localhost)"
+
+    if hostname in _LOCALHOST_HOSTNAMES:
+        return True, ""
+    if any(hostname == s.lstrip(".") or hostname.endswith(s) for s in _POSTHOG_HOST_SUFFIXES):
+        return True, ""
+    if os.environ.get("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", "").lower() == "true":
+        return True, ""
+
+    return False, (
+        f"POSTHOG_HOST {hostname!r} is not a known PostHog endpoint; "
+        "set POSTHOG_LLMA_ALLOW_CUSTOM_HOST=true to allow a self-hosted instance"
+    )
 
 
 def send_batch(
@@ -28,6 +79,10 @@ def send_batch(
     """
     if not events:
         return {"status": "ok", "sent": 0}
+
+    ok, reason = validate_host(host)
+    if not ok:
+        return {"status": "error", "error": f"refused to send: {reason}"}
 
     batch = []
     fallback_ts = datetime.now(timezone.utc).isoformat()

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -10,7 +10,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
-from posthog_llma.sender import send_batch, write_status, read_status, STATUS_FILE
+from posthog_llma.sender import send_batch, validate_host, write_status, read_status, STATUS_FILE
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +218,28 @@ class TestSendBatch:
         result = send_batch([], api_key="test", distinct_id="user")
         assert result == {"status": "ok", "sent": 0}
 
+    def test_refuses_unknown_host(self, monkeypatch):
+        monkeypatch.delenv("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", raising=False)
+        result = send_batch(
+            [{"event": "$ai_generation", "properties": {}}],
+            api_key="phc_test",
+            host="https://attacker.example.com",
+            distinct_id="u",
+        )
+        assert result["status"] == "error"
+        assert "refused to send" in result["error"]
+
+    def test_refuses_http_for_non_localhost(self, monkeypatch):
+        monkeypatch.delenv("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", raising=False)
+        result = send_batch(
+            [{"event": "$ai_generation", "properties": {}}],
+            api_key="phc_test",
+            host="http://us.i.posthog.com",
+            distinct_id="u",
+        )
+        assert result["status"] == "error"
+        assert "refused to send" in result["error"]
+
     def test_per_event_timestamps_used(self):
         from datetime import datetime, timezone
 
@@ -231,6 +253,53 @@ class TestSendBatch:
         assert timestamps[0] == "2026-04-12T10:00:00Z"
         assert timestamps[1] == "2026-04-12T10:01:00Z"
         assert timestamps[2] == fallback
+
+
+# ---------------------------------------------------------------------------
+# validate_host
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHost:
+    @pytest.mark.parametrize("host", [
+        "https://us.i.posthog.com",
+        "https://eu.i.posthog.com",
+        "https://app.posthog.com",
+        "https://posthog.com",
+        "https://us.i.posthog.com/",
+        "us.i.posthog.com",  # no scheme — defaulted to https
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+    ])
+    def test_accepts_known_endpoints(self, host, monkeypatch):
+        monkeypatch.delenv("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", raising=False)
+        ok, reason = validate_host(host)
+        assert ok, reason
+
+    @pytest.mark.parametrize("host", [
+        "https://attacker.example.com",
+        "https://evilposthog.com",       # substring, not suffix
+        "https://posthog.com.evil.com",  # suffix attack
+        "http://us.i.posthog.com",       # http to non-localhost
+        "ftp://us.i.posthog.com",        # bad scheme
+        "",                              # empty
+    ])
+    def test_rejects_untrusted_hosts(self, host, monkeypatch):
+        monkeypatch.delenv("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", raising=False)
+        ok, reason = validate_host(host)
+        assert not ok
+        assert reason
+
+    def test_self_hosted_opt_in(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", "true")
+        ok, reason = validate_host("https://posthog.internal.example.com")
+        assert ok, reason
+
+    def test_self_hosted_opt_in_still_requires_https(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_LLMA_ALLOW_CUSTOM_HOST", "true")
+        ok, reason = validate_host("http://posthog.internal.example.com")
+        assert not ok
+        assert "https" in reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `posthog_llma.sender.send_batch` now refuses to POST when `POSTHOG_HOST` is not a known PostHog endpoint. The default allowlist is `*.posthog.com` plus `localhost` / `127.0.0.1` for local development. Self-hosters opt in via `POSTHOG_LLMA_ALLOW_CUSTOM_HOST=true` and still must use `https://`.
- New `validate_host(host)` helper in `posthog_llma.sender`, exported from the package, returning `(ok, reason)` so future call sites can use it directly.
- Documents the new constraint in `README.md` and `commands/llma-cc-setup.md`.
- Bumps `.claude-plugin/plugin.json` to 1.1.21 (Claude-only change, matching the convention used by #59 and #42).

### Why

`POSTHOG_HOST` is read from environment, including project-scoped `.claude/settings.json`, with no validation. Telemetry payloads contain `\$ai_user_prompt`, `\$ai_input`, `\$ai_output_choices`, `\$ai_input_state` (every tool input), `\$ai_output_state` (every tool result, e.g. file contents from Read/Bash), the user's git email as `distinct_id`, and the PostHog API key in the request body. A malicious project-level settings file can therefore silently redirect every Claude Code session on a contributor's machine — and the user has no signal it happened. The validator closes that exfiltration vector with one default-deny check and one documented opt-in.

## Test plan

- [x] `pytest tests/test_session_parser.py tests/test_posthog_llma.py` — 69/69 pass (was 51, +18 new cases for `validate_host` and `send_batch` refusal paths)
- [x] Manually verified rejection of `https://attacker.example.com`, `http://us.i.posthog.com`, `https://posthog.com.evil.com`, `https://evilposthog.com`
- [x] Manually verified acceptance of `https://us.i.posthog.com`, `https://eu.i.posthog.com`, `https://posthog.com`, `http://localhost:8000`
- [x] Manually verified `POSTHOG_LLMA_ALLOW_CUSTOM_HOST=true` accepts `https://posthog.internal.example.com` but still rejects `http://...`
- [ ] CI green on this PR

## Notes

This is one of three security PRs from a strict-zero-trust audit of the repo; the other two cover the `gate-exec-write.sh` parser bypasses and the `sync-skills.yml` zip-slip / auto-merge concerns. They land independently of this one.