### PR TITLE
fix(ci): zip-slip-safe extraction in sync-skills workflow

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -10,6 +10,11 @@ on:
         required: false
         default: ''
 
+# Default-deny on the implicit GITHUB_TOKEN. The actual writes (commit + PR
+# create + auto-merge) flow through the GH App token plumbed in below, so the
+# implicit token does not need any scopes.
+permissions: {}
+
 jobs:
   sync-skills:
     runs-on: ubuntu-latest
@@ -53,19 +58,48 @@ jobs:
             done < "$MANIFEST"
           fi
 
+          # Zip-slip-safe extractor. Plain `unzip -o` does not validate
+          # entries — a malicious archive with `../` traversal could write
+          # outside the destination and tamper with workflow files,
+          # `.git/`, or other ai-plugin source. We validate every entry's
+          # resolved path is contained within $dest before extracting any
+          # member.
+          safe_unzip() {
+            local archive="$1" dest="$2"
+            python3 - "$archive" "$dest" <<'PY'
+          import os
+          import sys
+          import zipfile
+
+          archive, dest = sys.argv[1], sys.argv[2]
+          os.makedirs(dest, exist_ok=True)
+          dest_abs = os.path.realpath(dest)
+
+          with zipfile.ZipFile(archive) as zf:
+              for member in zf.infolist():
+                  name = member.filename
+                  if name.startswith("/") or os.path.isabs(name) or ".." in name.split("/"):
+                      sys.exit(f"refusing entry {name!r} in {archive!r}: traversal or absolute path")
+                  target = os.path.realpath(os.path.join(dest_abs, name))
+                  if target != dest_abs and not target.startswith(dest_abs + os.sep):
+                      sys.exit(f"refusing entry {name!r} in {archive!r}: escapes {dest!r}")
+              zf.extractall(dest)
+          PY
+          }
+
           # Extract PostHog release skills
-          unzip -o /tmp/skills.zip -d skills/
+          safe_unzip /tmp/skills.zip skills/
 
           # Extract context-mill skills (nested zips, strip omnibus- prefix)
           tmp_cm=$(mktemp -d)
           cm_manifest=$(mktemp)
-          unzip -q -o /tmp/context-mill.zip -d "$tmp_cm"
+          safe_unzip /tmp/context-mill.zip "$tmp_cm"
           while read -r inner_zip; do
             skill_name="$(basename "$inner_zip" .zip)"
             skill_name="${skill_name#omnibus-}"
             echo "$skill_name" >> "$cm_manifest"
             mkdir -p "skills/$skill_name"
-            unzip -q -o "$inner_zip" -d "skills/$skill_name"
+            safe_unzip "$inner_zip" "skills/$skill_name"
             find "skills/$skill_name" -name 'SKILL.md' -type f -exec sed -i 's/^\(name: *\)omnibus-/\1/' {} +
             find "skills/$skill_name" -name 'SKILL.md' -type f -exec sed -i '/^  version: .*/d' {} +
           done < <(find "$tmp_cm" -name 'omnibus-*.zip' -type f)


### PR DESCRIPTION
## Summary

- Replaces the three `unzip -o` calls inside `sync-skills.yml` with a `safe_unzip` shell function backed by python's `zipfile` module. Every entry's resolved path is checked against the destination root; absolute paths and `..` traversal are rejected before any member is extracted.
- Adds `permissions: {}` at the workflow root. The destructive writes (commit, PR creation, auto-merge) flow through the explicit GH App token already plumbed into the workflow, so the implicit `GITHUB_TOKEN` does not need any scope.

### Why

`unzip -o` happily writes to whatever path the archive specifies — including `../foo` and `/etc/foo` — meaning a tampered `skills.zip` from `PostHog/posthog` or `skills-mcp-resources.zip` from `PostHog/context-mill` can write outside `skills/` during the daily sync. The reachable blast radius on the runner includes `.github/workflows/`, `hooks/`, `scripts/`, and `.git/` — all files the next workflow run picks up via `actions/checkout`. Even though the immediate trust chain (PostHog/posthog → ai-plugin) is internal, the workflow runs daily on a cron with broad write authority, so it deserves defensive parsing rather than implicit trust.

The auto-merge step at the end of the workflow is intentionally untouched — that is a maintainer policy decision and out of scope for the security fix.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/sync-skills.yml'))"` parses cleanly
- [x] Empirically tested the extractor logic against three crafted archives:
  - `clean.zip` with normal entries → extracts (rc=0)
  - `traverse.zip` containing `../escaped.txt` → refused (rc=1, "traversal or absolute path")
  - `absolute.zip` containing `/etc/test.txt` → refused (rc=1, "traversal or absolute path")
- [ ] CI green on this PR
- [ ] Next scheduled sync run completes successfully against legitimate `agent-skills-latest` and context-mill releases

## Notes

This is one of three security PRs from a strict-zero-trust audit; the other two cover `POSTHOG_HOST` validation (#68) and the `gate-exec-write.sh` parser bypasses (#69). They land independently of this one.