### PR TITLE
fix(llma): four Claude Code ingest bugs (#48, #55, #85)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -1,5 +1,6 @@
 """Build PostHog events from parsed Claude Code session data."""
 
+import hashlib
 import json
 import os
 import uuid
@@ -8,6 +9,19 @@ from typing import Optional
 
 from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
 from posthog_llma.trace_naming import find_trace_name
+
+
+def _insert_id(*parts: str) -> str:
+    """Deterministic $insert_id for PostHog dedup.
+
+    The SessionEnd hook re-reads the full JSONL on every fire (including
+    after `claude --resume`), so the same generation/tool/trace gets re-built
+    and re-sent with fresh random span IDs. Passing a stable $insert_id
+    derived from session-stable identifiers (session_id + msg_id, etc.)
+    lets PostHog dedupe re-sends into a single ingested event.
+    """
+    key = "|".join(p or "" for p in parts)
+    return hashlib.sha1(key.encode("utf-8")).hexdigest()
 
 
 def _truncate_tool_blocks(blocks: list, max_len: int) -> list:
@@ -107,6 +121,10 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             privacy_mode=privacy_mode,
             extra_properties=custom_properties,
             timestamp=gen.get("timestamp"),
+            insert_id=_insert_id(
+                "cc-gen", session_id,
+                gen.get("msg_id") or gen["span_id"],
+            ),
         ))
 
     # -- $ai_span events --
@@ -149,6 +167,12 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             max_attribute_length=config.get("max_attribute_length", 12000),
             extra_properties=custom_properties,
             timestamp=tu.get("timestamp"),
+            insert_id=_insert_id(
+                "cc-span", session_id,
+                tu.get("tool_use_id") or "",
+                tu.get("name") or "",
+                tu.get("timestamp") or "",
+            ),
         ))
 
     # -- $ai_trace events --
@@ -194,6 +218,7 @@ def _build_session_trace(events, parsed, all_generations, trace_id, session_id, 
         project_name=project_name,
         extra_properties=custom_properties,
         timestamp=trace_ts,
+        insert_id=_insert_id("cc-trace-session", session_id),
     ))
 
 
@@ -229,6 +254,7 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
             project_name=project_name,
             extra_properties=custom_properties,
             timestamp=prompt_ts,
+            insert_id=_insert_id("cc-trace-msg", session_id, pid),
         ))
 
     # Emit root trace events for fallback (unresolved prompt) trace IDs
@@ -258,4 +284,5 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
                 project_name=project_name,
                 extra_properties=custom_properties,
                 timestamp=timestamps[0] if timestamps else None,
+                insert_id=_insert_id("cc-trace-fallback", session_id, trace_id),
             ))

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -1,6 +1,5 @@
 """Build PostHog events from parsed Claude Code session data."""
 
-import hashlib
 import json
 import os
 import uuid
@@ -10,18 +9,28 @@ from typing import Optional
 from posthog_llma.events import build_ai_generation, build_ai_span, build_ai_trace
 from posthog_llma.trace_naming import find_trace_name
 
+# Stable namespace for deriving deterministic event UUIDs via uuid5.
+# Don't change — would break dedup against previously ingested events.
+_UUID_NAMESPACE = uuid.UUID("a3c3f6c2-9b8e-4a3e-b3a1-7e6b8e9a0f00")
+
 
 def _insert_id(*parts: str) -> str:
-    """Deterministic $insert_id for PostHog dedup.
+    """Deterministic identifier for PostHog dedup.
 
     The SessionEnd hook re-reads the full JSONL on every fire (including
-    after `claude --resume`), so the same generation/tool/trace gets re-built
-    and re-sent with fresh random span IDs. Passing a stable $insert_id
-    derived from session-stable identifiers (session_id + msg_id, etc.)
-    lets PostHog dedupe re-sends into a single ingested event.
+    after `claude --resume`), so the same generation/tool/trace gets
+    re-built and re-sent with fresh random span IDs. A stable identifier
+    derived from session-stable inputs (session_id + msg_id, etc.) lets
+    PostHog dedupe re-sends.
+
+    Returned as a UUIDv5. The PostHog `/batch` endpoint dedupes on the
+    event's top-level `uuid` field (the `events` table is a ClickHouse
+    ReplacingMergeTree keyed by uuid); `$insert_id` as a property is
+    *not* a dedup signal on this path. We set both — uuid drives the
+    actual dedup, the $insert_id property doubles as a debug marker.
     """
     key = "|".join(p or "" for p in parts)
-    return hashlib.sha1(key.encode("utf-8")).hexdigest()
+    return str(uuid.uuid5(_UUID_NAMESPACE, key))
 
 
 def _truncate_tool_blocks(blocks: list, max_len: int) -> list:

--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -82,6 +82,8 @@ def build_ai_generation(
         properties["$insert_id"] = insert_id
 
     result = {"event": "$ai_generation", "properties": properties}
+    if insert_id:
+        result["uuid"] = insert_id
     if timestamp:
         result["timestamp"] = timestamp
     return result
@@ -141,6 +143,8 @@ def build_ai_span(
         properties["$insert_id"] = insert_id
 
     result = {"event": "$ai_span", "properties": properties}
+    if insert_id:
+        result["uuid"] = insert_id
     if timestamp:
         result["timestamp"] = timestamp
     return result
@@ -188,6 +192,8 @@ def build_ai_trace(
         properties["$insert_id"] = insert_id
 
     result = {"event": "$ai_trace", "properties": properties}
+    if insert_id:
+        result["uuid"] = insert_id
     if timestamp:
         result["timestamp"] = timestamp
     return result

--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -34,8 +34,14 @@ def build_ai_generation(
     privacy_mode: bool = False,
     extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
+    insert_id: Optional[str] = None,
 ) -> dict:
-    """Build a $ai_generation event."""
+    """Build a $ai_generation event.
+
+    Pass `insert_id` to set `$insert_id` for PostHog dedup. Use a
+    deterministic value (e.g. derived from session_id + message_id) so
+    re-sends of the same generation collapse into a single ingested event.
+    """
     total_tokens = input_tokens + output_tokens
 
     # Map Claude Code stop reasons to PostHog's expected values
@@ -72,6 +78,9 @@ def build_ai_generation(
     if extra_properties:
         properties.update(extra_properties)
 
+    if insert_id:
+        properties["$insert_id"] = insert_id
+
     result = {"event": "$ai_generation", "properties": properties}
     if timestamp:
         result["timestamp"] = timestamp
@@ -96,8 +105,12 @@ def build_ai_span(
     max_attribute_length: int = 12000,
     extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
+    insert_id: Optional[str] = None,
 ) -> dict:
-    """Build a $ai_span event for a tool execution."""
+    """Build a $ai_span event for a tool execution.
+
+    Pass `insert_id` to set `$insert_id` for PostHog dedup.
+    """
     def _truncate(val, max_len):
         if val is None:
             return None
@@ -124,6 +137,9 @@ def build_ai_span(
     if extra_properties:
         properties.update(extra_properties)
 
+    if insert_id:
+        properties["$insert_id"] = insert_id
+
     result = {"event": "$ai_span", "properties": properties}
     if timestamp:
         result["timestamp"] = timestamp
@@ -144,8 +160,12 @@ def build_ai_trace(
     agent_name: str = "",
     extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
+    insert_id: Optional[str] = None,
 ) -> dict:
-    """Build a $ai_trace event for a complete prompt-to-response cycle."""
+    """Build a $ai_trace event for a complete prompt-to-response cycle.
+
+    Pass `insert_id` to set `$insert_id` for PostHog dedup.
+    """
     properties = {
         "$ai_trace_id": trace_id,
         "$ai_trace_name": trace_name,
@@ -163,6 +183,9 @@ def build_ai_trace(
 
     if extra_properties:
         properties.update(extra_properties)
+
+    if insert_id:
+        properties["$insert_id"] = insert_id
 
     result = {"event": "$ai_trace", "properties": properties}
     if timestamp:

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -286,14 +286,21 @@ def _process_assistant_entry(
             "span_id": str(uuid.uuid4()),
             "msg_id": msg_id,
             "blocks_by_type": {"thinking": [], "text": [], "tool_use": []},
+            # Order types by first appearance across chunks rather than
+            # assuming thinking → text → tool_use. Most Anthropic streams
+            # do follow that order, but if a chunk arrives text-first the
+            # output sequence should still reflect what the model produced.
+            "type_order": [],
             "error_message": msg.get("error_message"),
         }
         generations_by_msg_id[key] = state
         generations_order.append(key)
 
-    # Merge content blocks per type
+    # Merge content blocks per type, preserving first-seen order
     for t, blocks in entry_blocks_by_type.items():
         if blocks:
+            if t not in state["type_order"]:
+                state["type_order"].append(t)
             state["blocks_by_type"][t] = blocks
 
     # Take latest non-empty metadata
@@ -320,26 +327,33 @@ def _finalize_generation(state: dict) -> tuple[dict, list]:
     usage = state.get("usage") or {}
 
     blocks = state["blocks_by_type"]
-    text_parts = []
-    for item in blocks["thinking"]:
-        t = item.get("thinking", "")
-        if t:
-            text_parts.append(t)
-    for item in blocks["text"]:
-        t = item.get("text", "")
-        if t:
-            text_parts.append(t)
+    # Fall back to a sensible default order for older state dicts; new
+    # entries populate type_order in first-seen order during the merge.
+    type_order = state.get("type_order") or ["thinking", "text", "tool_use"]
 
+    text_parts = []
     entry_tool_uses = []
-    for item in blocks["tool_use"]:
-        entry_tool_uses.append({
-            "tool_use_id": item.get("id", ""),
-            "name": item.get("name", "unknown"),
-            "input": item.get("input"),
-            "generation_span_id": span_id,
-            "prompt_id": prompt_id,
-            "timestamp": timestamp,
-        })
+    for block_type in type_order:
+        if block_type == "thinking":
+            for item in blocks.get("thinking", []):
+                t = item.get("thinking", "")
+                if t:
+                    text_parts.append(t)
+        elif block_type == "text":
+            for item in blocks.get("text", []):
+                t = item.get("text", "")
+                if t:
+                    text_parts.append(t)
+        elif block_type == "tool_use":
+            for item in blocks.get("tool_use", []):
+                entry_tool_uses.append({
+                    "tool_use_id": item.get("id", ""),
+                    "name": item.get("name", "unknown"),
+                    "input": item.get("input"),
+                    "generation_span_id": span_id,
+                    "prompt_id": prompt_id,
+                    "timestamp": timestamp,
+                })
 
     tool_use_blocks = [
         {"type": "tool_use", "name": tu["name"], "input": tu.get("input")}

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -102,9 +102,15 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
 
             entry_type = entry.get("type", "")
 
-            # Session metadata
+            # Session metadata. The Claude Code CLI emits a permission-mode
+            # entry at the top of every session, but the Claude Agent SDK
+            # JSONL format does not — every entry just carries `sessionId`.
+            # Pull it opportunistically so SDK sessions still get a non-empty
+            # $ai_session_id / $ai_trace_id.
+            if not session_id:
+                session_id = entry.get("sessionId", "") or session_id
             if entry_type == "permission-mode":
-                session_id = entry.get("sessionId", "")
+                session_id = entry.get("sessionId", "") or session_id
 
             # User messages (prompts + tool results)
             if entry_type == "user":

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -14,12 +14,22 @@ def find_session_log(session_id: str, cwd: str) -> Optional[str]:
     """Find the JSONL session log file.
 
     Claude Code stores logs at:
-        ~/.claude/projects/{cwd-with-slashes-replaced}/{session_id}.jsonl
+        ~/.claude/projects/{cwd-with-special-chars-replaced}/{session_id}.jsonl
+
+    Claude Code collapses `/`, `.`, `\\`, `:`, `_`, and spaces to `-` when
+    naming the project dir, and the exact rules have drifted across versions
+    and platforms (Windows paths, paths under `.claude` worktrees, paths
+    with underscores or spaces, etc.). Rather than mirror that rule set, we
+    try the direct lookup first and fall back to a glob across project dirs
+    — session IDs are UUIDs and unique, so the match is unambiguous.
     """
+    base = Path.home() / ".claude" / "projects"
     project_dir_name = cwd.replace("/", "-")
-    path = Path.home() / ".claude" / "projects" / project_dir_name / f"{session_id}.jsonl"
-    if path.is_file():
-        return str(path)
+    direct = base / project_dir_name / f"{session_id}.jsonl"
+    if direct.is_file():
+        return str(direct)
+    for candidate in base.glob(f"*/{session_id}.jsonl"):
+        return str(candidate)
     return None
 
 

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -287,6 +287,7 @@ def _process_assistant_entry(
         "timestamp": timestamp,
         "prompt_id": prompt_id,
         "span_id": span_id,
+        "msg_id": msg_id,
         "output_text": output_text,
         "tool_use_blocks": tool_use_blocks,
         "is_error": stop_reason == "error",

--- a/posthog_llma/parser.py
+++ b/posthog_llma/parser.py
@@ -141,11 +141,11 @@ def parse_session(jsonl_path: str, config: dict) -> dict:
             if not metadata.get("git_branch"):
                 metadata["git_branch"] = entry.get("gitBranch", "")
 
-    # Flatten deduplicated generations and tool uses
+    # Flatten merged per-msg_id states into generations + tool_uses
     generations = []
     tool_uses = []
     for key in generations_order:
-        gen, tus = generations_by_msg_id[key]
+        gen, tus = _finalize_generation(generations_by_msg_id[key])
         generations.append(gen)
         tool_uses.extend(tus)
 
@@ -235,9 +235,21 @@ def _process_assistant_entry(
 ) -> None:
     """Process an assistant-type JSONL entry.
 
-    Session logs can have duplicate entries for the same message
-    (streaming updates). The later entry is more complete (has
-    tool_use blocks), so we overwrite earlier entries per message ID.
+    Session logs can have multiple entries for the same message ID, and
+    the Claude Agent SDK splits content blocks across them — one entry
+    may carry only `thinking`, the next only `tool_use`, the next only
+    `text`. Naively overwriting per msg_id drops every block except the
+    last entry's, so thinking content vanishes from $ai_output_choices.
+
+    Instead, merge per content type:
+      - When an entry carries blocks of a type we've seen, replace that
+        type's blocks (handles cumulative streaming where each chunk
+        repeats prior content in a longer form).
+      - When an entry carries blocks of a type we haven't seen, add them
+        (handles delta streaming where each chunk has only new content).
+
+    Usage/stop_reason/timestamp/model are taken from the latest non-empty
+    chunk — Claude Code typically emits these on the final entry.
     """
     msg = entry.get("message", {})
     if msg.get("role") != "assistant":
@@ -245,46 +257,99 @@ def _process_assistant_entry(
 
     msg_id = msg.get("id", "")
     usage = msg.get("usage", {})
-    model = msg.get("model", "unknown")
+    model = msg.get("model", "")
     stop_reason = msg.get("stop_reason")
     timestamp = entry.get("timestamp", "")
     entry_uuid = entry.get("uuid", "")
     prompt_id = resolve_prompt_id(entry_uuid)
-    span_id = str(uuid.uuid4())
 
-    # Extract text, thinking blocks, and tool_use blocks
+    # Group this entry's content blocks by type
+    entry_blocks_by_type = {"thinking": [], "text": [], "tool_use": []}
     content = msg.get("content", [])
-    text_parts = []
-    entry_tool_uses = []
-
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict):
-                if item.get("type") == "text":
-                    text_parts.append(item.get("text", ""))
-                elif item.get("type") == "thinking":
-                    thinking_text = item.get("thinking", "")
-                    if thinking_text:
-                        text_parts.append(thinking_text)
-                elif item.get("type") == "tool_use":
-                    entry_tool_uses.append({
-                        "tool_use_id": item.get("id", ""),
-                        "name": item.get("name", "unknown"),
-                        "input": item.get("input"),
-                        "generation_span_id": span_id,
-                        "prompt_id": prompt_id,
-                        "timestamp": timestamp,
-                    })
+                t = item.get("type")
+                if t in entry_blocks_by_type:
+                    entry_blocks_by_type[t].append(item)
 
-    output_text = "\n".join(text_parts) if text_parts else None
+    key = msg_id or entry_uuid or str(uuid.uuid4())
+
+    state = generations_by_msg_id.get(key)
+    if state is None:
+        state = {
+            "model": model or "unknown",
+            "usage": usage,
+            "stop_reason": stop_reason,
+            "timestamp": timestamp,
+            "prompt_id": prompt_id,
+            "span_id": str(uuid.uuid4()),
+            "msg_id": msg_id,
+            "blocks_by_type": {"thinking": [], "text": [], "tool_use": []},
+            "error_message": msg.get("error_message"),
+        }
+        generations_by_msg_id[key] = state
+        generations_order.append(key)
+
+    # Merge content blocks per type
+    for t, blocks in entry_blocks_by_type.items():
+        if blocks:
+            state["blocks_by_type"][t] = blocks
+
+    # Take latest non-empty metadata
+    if usage:
+        state["usage"] = usage
+    if stop_reason:
+        state["stop_reason"] = stop_reason
+    if timestamp:
+        state["timestamp"] = timestamp
+    if model:
+        state["model"] = model
+    if msg.get("error_message"):
+        state["error_message"] = msg["error_message"]
+    # prompt_id can resolve later as more entries arrive
+    if not state["prompt_id"] and prompt_id:
+        state["prompt_id"] = prompt_id
+
+
+def _finalize_generation(state: dict) -> tuple[dict, list]:
+    """Convert a merged per-msg_id state into a (generation, tool_uses) pair."""
+    span_id = state["span_id"]
+    prompt_id = state["prompt_id"]
+    timestamp = state["timestamp"]
+    usage = state.get("usage") or {}
+
+    blocks = state["blocks_by_type"]
+    text_parts = []
+    for item in blocks["thinking"]:
+        t = item.get("thinking", "")
+        if t:
+            text_parts.append(t)
+    for item in blocks["text"]:
+        t = item.get("text", "")
+        if t:
+            text_parts.append(t)
+
+    entry_tool_uses = []
+    for item in blocks["tool_use"]:
+        entry_tool_uses.append({
+            "tool_use_id": item.get("id", ""),
+            "name": item.get("name", "unknown"),
+            "input": item.get("input"),
+            "generation_span_id": span_id,
+            "prompt_id": prompt_id,
+            "timestamp": timestamp,
+        })
 
     tool_use_blocks = [
         {"type": "tool_use", "name": tu["name"], "input": tu.get("input")}
         for tu in entry_tool_uses
     ]
+    output_text = "\n".join(text_parts) if text_parts else None
+    stop_reason = state.get("stop_reason")
 
     generation = {
-        "model": model,
+        "model": state.get("model") or "unknown",
         "input_tokens": usage.get("input_tokens", 0),
         "output_tokens": usage.get("output_tokens", 0),
         "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
@@ -293,14 +358,10 @@ def _process_assistant_entry(
         "timestamp": timestamp,
         "prompt_id": prompt_id,
         "span_id": span_id,
-        "msg_id": msg_id,
+        "msg_id": state.get("msg_id", ""),
         "output_text": output_text,
         "tool_use_blocks": tool_use_blocks,
         "is_error": stop_reason == "error",
-        "error_message": msg.get("error_message"),
+        "error_message": state.get("error_message"),
     }
-
-    key = msg_id or entry_uuid or str(uuid.uuid4())
-    if key not in generations_by_msg_id:
-        generations_order.append(key)
-    generations_by_msg_id[key] = (generation, entry_tool_uses)
+    return generation, entry_tool_uses

--- a/posthog_llma/sender.py
+++ b/posthog_llma/sender.py
@@ -33,7 +33,7 @@ def send_batch(
     fallback_ts = datetime.now(timezone.utc).isoformat()
 
     for ev in events:
-        batch.append({
+        entry = {
             "event": ev["event"],
             "properties": {
                 **ev["properties"],
@@ -41,7 +41,13 @@ def send_batch(
             },
             "distinct_id": distinct_id,
             "timestamp": ev.get("timestamp") or fallback_ts,
-        })
+        }
+        # PostHog's /batch endpoint dedupes on the event-level `uuid`
+        # field via ClickHouse's ReplacingMergeTree. Pass through when
+        # the builder set it (deterministic uuid5 in event_builder.py).
+        if ev.get("uuid"):
+            entry["uuid"] = ev["uuid"]
+        batch.append(entry)
 
     payload = json.dumps({
         "api_key": api_key,

--- a/scripts/dev_test_session.py
+++ b/scripts/dev_test_session.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Launch a Claude Code session against the local (or a remote-branch)
+build of this plugin, with the marketplace plugin disabled so SessionEnd
+doesn't double-fire.
+
+Examples:
+    scripts/dev_test_session.py
+        # Load this repo at its current checkout via --plugin-dir.
+
+    scripts/dev_test_session.py --branch fix/claude-code-ingest-bugs
+        # Load the branch zip from GitHub via --plugin-url.
+
+    scripts/dev_test_session.py --cwd ~/some/other/project
+        # Run the session in a different working dir (useful for testing
+        # path-mangling cases like worktrees, spaces, underscores, dots).
+
+The marketplace plugin (posthog@claude-plugins-official) is disabled at
+session start and re-enabled in a finally block, so an interrupted run
+still restores it. Re-running while it's already disabled is harmless.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+MARKETPLACE_PLUGIN = "posthog@claude-plugins-official"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REQUIRED_ENV = ("POSTHOG_LLMA_CC_ENABLED", "POSTHOG_API_KEY")
+
+
+def _git_branch(cwd: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd, text=True, stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "(unknown)"
+
+
+def _warn_missing_env(target_cwd: Path) -> None:
+    """Warn if the env vars the hook needs aren't visible in this shell
+    AND aren't present in the target cwd's .claude/settings*.json. The
+    hook will silently no-op without these — easy to miss."""
+    shell_missing = [k for k in REQUIRED_ENV if not os.environ.get(k)]
+    if not shell_missing:
+        return
+
+    found_in_settings = set()
+    for fname in ("settings.json", "settings.local.json"):
+        path = target_cwd / ".claude" / fname
+        if path.is_file():
+            text = path.read_text(errors="ignore")
+            for k in shell_missing:
+                if f'"{k}"' in text:
+                    found_in_settings.add(k)
+
+    still_missing = [k for k in shell_missing if k not in found_in_settings]
+    if still_missing:
+        print(
+            f"warning: {', '.join(still_missing)} not set in this shell "
+            f"and not found in {target_cwd}/.claude/settings*.json — "
+            f"the SessionEnd hook will silently no-op.",
+            file=sys.stderr,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--branch",
+        help="Load a remote branch zip via --plugin-url instead of the local repo.",
+    )
+    parser.add_argument(
+        "--repo", default="PostHog/ai-plugin",
+        help="owner/repo for --branch (default: PostHog/ai-plugin).",
+    )
+    parser.add_argument(
+        "--cwd", default=os.getcwd(),
+        help="Working dir to launch claude in (default: current).",
+    )
+    parser.add_argument(
+        "--skip-disable", action="store_true",
+        help="Don't disable the marketplace plugin. Causes duplicate "
+             "SessionEnd events; only use if you're isolating something else.",
+    )
+    parser.add_argument(
+        "claude_args", nargs=argparse.REMAINDER,
+        help="Extra args passed through to `claude` (prefix with --).",
+    )
+    args = parser.parse_args()
+
+    target_cwd = Path(args.cwd).expanduser().resolve()
+    if not target_cwd.is_dir():
+        print(f"error: --cwd not a directory: {target_cwd}", file=sys.stderr)
+        return 2
+
+    if args.branch:
+        url = f"https://github.com/{args.repo}/archive/refs/heads/{args.branch}.zip"
+        plugin_args = ["--plugin-url", url]
+        print(f"plugin source: remote — {args.repo}@{args.branch}")
+        print(f"               {url}")
+    else:
+        plugin_args = ["--plugin-dir", str(REPO_ROOT)]
+        print(f"plugin source: local  — {REPO_ROOT}")
+        print(f"               branch: {_git_branch(REPO_ROOT)}")
+
+    print(f"cwd:           {target_cwd}")
+    _warn_missing_env(target_cwd)
+
+    disabled = False
+    if not args.skip_disable:
+        print(f"disabling {MARKETPLACE_PLUGIN} for this session...")
+        result = subprocess.run(
+            ["claude", "plugin", "disable", MARKETPLACE_PLUGIN],
+            capture_output=True, text=True,
+        )
+        # `disable` returns 0 even if already disabled, so accept that.
+        disabled = result.returncode == 0
+        if not disabled:
+            print(f"warning: disable failed:\n{result.stderr}", file=sys.stderr)
+
+    # Pass-through extra claude args; REMAINDER includes the leading "--"
+    # if the user used one, so strip it.
+    extra = args.claude_args
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+
+    try:
+        cmd = ["claude", *plugin_args, *extra]
+        print(f"launching:     {' '.join(cmd)}\n")
+        rc = subprocess.run(cmd, cwd=str(target_cwd)).returncode
+    finally:
+        if disabled:
+            print(f"\nre-enabling {MARKETPLACE_PLUGIN}...")
+            subprocess.run(
+                ["claude", "plugin", "enable", MARKETPLACE_PLUGIN],
+                capture_output=True,
+            )
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -232,6 +232,48 @@ class TestSendBatch:
         assert timestamps[1] == "2026-04-12T10:01:00Z"
         assert timestamps[2] == fallback
 
+    def test_insert_id_survives_send_batch(self, monkeypatch):
+        """Regression coverage for #85: $insert_id set on the event
+        properties must reach PostHog's /batch payload — otherwise the
+        deterministic-dedup work upstream is wasted."""
+        import json
+
+        captured = {}
+
+        class _FakeResponse:
+            status = 200
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b""
+
+        def fake_urlopen(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _FakeResponse()
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        events = [
+            {
+                "event": "$ai_generation",
+                "properties": {"$ai_model": "claude", "$insert_id": "stable-id-1"},
+                "timestamp": "2026-04-12T10:00:00Z",
+            },
+            {
+                "event": "$ai_span",
+                "properties": {"$ai_span_name": "Bash", "$insert_id": "stable-id-2"},
+                "timestamp": "2026-04-12T10:00:01Z",
+            },
+        ]
+        result = send_batch(events, api_key="phc_test", distinct_id="user@example.com")
+        assert result["status"] == "ok"
+
+        sent = captured["body"]["batch"]
+        assert len(sent) == 2
+        assert sent[0]["properties"]["$insert_id"] == "stable-id-1"
+        assert sent[1]["properties"]["$insert_id"] == "stable-id-2"
+        # The $lib merge in sender.send_batch must not clobber $insert_id
+        assert sent[0]["properties"]["$lib"] == "posthog-ai-plugin"
+
 
 # ---------------------------------------------------------------------------
 # Status file

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -232,10 +232,11 @@ class TestSendBatch:
         assert timestamps[1] == "2026-04-12T10:01:00Z"
         assert timestamps[2] == fallback
 
-    def test_insert_id_survives_send_batch(self, monkeypatch):
-        """Regression coverage for #85: $insert_id set on the event
-        properties must reach PostHog's /batch payload — otherwise the
-        deterministic-dedup work upstream is wasted."""
+    def test_dedup_key_survives_send_batch(self, monkeypatch):
+        """Regression coverage for #85: PostHog's /batch endpoint dedupes
+        on the event-level `uuid` field (ClickHouse ReplacingMergeTree),
+        NOT on properties.$insert_id. The sender must forward the
+        builder-set top-level uuid so dedup actually kicks in."""
         import json
 
         captured = {}
@@ -255,12 +256,14 @@ class TestSendBatch:
         events = [
             {
                 "event": "$ai_generation",
-                "properties": {"$ai_model": "claude", "$insert_id": "stable-id-1"},
+                "uuid": "abcd1234-aaaa-5bbb-9ccc-deadbeef0001",
+                "properties": {"$ai_model": "claude", "$insert_id": "abcd1234-aaaa-5bbb-9ccc-deadbeef0001"},
                 "timestamp": "2026-04-12T10:00:00Z",
             },
             {
                 "event": "$ai_span",
-                "properties": {"$ai_span_name": "Bash", "$insert_id": "stable-id-2"},
+                "uuid": "abcd1234-aaaa-5bbb-9ccc-deadbeef0002",
+                "properties": {"$ai_span_name": "Bash", "$insert_id": "abcd1234-aaaa-5bbb-9ccc-deadbeef0002"},
                 "timestamp": "2026-04-12T10:00:01Z",
             },
         ]
@@ -269,10 +272,40 @@ class TestSendBatch:
 
         sent = captured["body"]["batch"]
         assert len(sent) == 2
-        assert sent[0]["properties"]["$insert_id"] == "stable-id-1"
-        assert sent[1]["properties"]["$insert_id"] == "stable-id-2"
-        # The $lib merge in sender.send_batch must not clobber $insert_id
+        # Top-level uuid is the actual dedup key
+        assert sent[0]["uuid"] == "abcd1234-aaaa-5bbb-9ccc-deadbeef0001"
+        assert sent[1]["uuid"] == "abcd1234-aaaa-5bbb-9ccc-deadbeef0002"
+        # Property is preserved as a debug marker
+        assert sent[0]["properties"]["$insert_id"] == "abcd1234-aaaa-5bbb-9ccc-deadbeef0001"
+        # The $lib merge in sender.send_batch must not clobber anything
         assert sent[0]["properties"]["$lib"] == "posthog-ai-plugin"
+
+    def test_uuid_omitted_when_not_set(self, monkeypatch):
+        """Generic callers that don't set a top-level uuid still work —
+        the sender doesn't fabricate one, PostHog assigns server-side."""
+        import json
+
+        captured = {}
+
+        class _FakeResponse:
+            status = 200
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b""
+
+        def fake_urlopen(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _FakeResponse()
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        events = [{
+            "event": "$ai_generation",
+            "properties": {"$ai_model": "claude"},
+            "timestamp": "2026-04-12T10:00:00Z",
+        }]
+        send_batch(events, api_key="phc_test", distinct_id="u")
+        assert "uuid" not in captured["body"]["batch"][0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -717,8 +717,13 @@ class TestBuildEvents:
             os.unlink(path)
 
     def test_insert_id_set_on_all_events(self):
-        """Regression coverage for #85: deterministic $insert_id lets
-        PostHog dedupe re-sends of the same session."""
+        """Regression coverage for #85: deterministic dedup key lets
+        PostHog dedupe re-sends of the same session.
+
+        PostHog's /batch endpoint dedupes on the event-level `uuid`
+        field via ClickHouse's ReplacingMergeTree. $insert_id in
+        properties is kept as a visible mirror so the dedup key is
+        easy to spot in the UI."""
         path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
         try:
             parsed = parse_session(path, DEFAULT_CONFIG)
@@ -726,10 +731,13 @@ class TestBuildEvents:
             for e in events:
                 assert e["properties"].get("$insert_id"), \
                     f"{e['event']} missing $insert_id"
+                assert e.get("uuid"), f"{e['event']} missing top-level uuid"
+                # Both must match — uuid is what PostHog actually dedupes on
+                assert e["uuid"] == e["properties"]["$insert_id"]
 
-            # Insert IDs must be unique within a single send
-            ids = [e["properties"]["$insert_id"] for e in events]
-            assert len(ids) == len(set(ids))
+            # Dedup keys must be unique within a single send
+            uuids = [e["uuid"] for e in events]
+            assert len(uuids) == len(set(uuids))
         finally:
             os.unlink(path)
 

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -381,6 +381,50 @@ class TestBuildEvents:
         finally:
             os.unlink(path)
 
+    def test_insert_id_set_on_all_events(self):
+        """Regression coverage for #85: deterministic $insert_id lets
+        PostHog dedupe re-sends of the same session."""
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            for e in events:
+                assert e["properties"].get("$insert_id"), \
+                    f"{e['event']} missing $insert_id"
+
+            # Insert IDs must be unique within a single send
+            ids = [e["properties"]["$insert_id"] for e in events]
+            assert len(ids) == len(set(ids))
+        finally:
+            os.unlink(path)
+
+    def test_insert_id_stable_across_reparses(self):
+        """Same JSONL parsed twice yields identical $insert_ids, so PostHog
+        dedupes — even though span_ids are regenerated each parse."""
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            events_a = build_events(parse_session(path, DEFAULT_CONFIG), DEFAULT_CONFIG)
+            events_b = build_events(parse_session(path, DEFAULT_CONFIG), DEFAULT_CONFIG)
+
+            ids_a = sorted(e["properties"]["$insert_id"] for e in events_a)
+            ids_b = sorted(e["properties"]["$insert_id"] for e in events_b)
+            assert ids_a == ids_b
+        finally:
+            os.unlink(path)
+
+    def test_insert_id_stable_in_message_mode(self):
+        config = {**DEFAULT_CONFIG, "trace_grouping": "message"}
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            events_a = build_events(parse_session(path, config), config)
+            events_b = build_events(parse_session(path, config), config)
+
+            ids_a = sorted(e["properties"]["$insert_id"] for e in events_a)
+            ids_b = sorted(e["properties"]["$insert_id"] for e in events_b)
+            assert ids_a == ids_b
+        finally:
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # trace naming

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -256,6 +256,46 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
+    def test_session_id_extracted_from_agent_sdk_jsonl(self):
+        """Regression coverage for #55 Defect 1: Claude Agent SDK JSONLs
+        don't emit a permission-mode entry, but every entry carries
+        sessionId. The parser should still pick it up."""
+        # No permission-mode entry, no system/turn_duration entry.
+        entries = [
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "hi"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "sdk-session-abc",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 10, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "sdk-session-abc",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert parsed["session_id"] == "sdk-session-abc"
+
+            # Downstream events must have a non-empty trace_id / session_id
+            events = build_events(parsed, DEFAULT_CONFIG)
+            for e in events:
+                assert e["properties"]["$ai_session_id"] == "sdk-session-abc"
+                assert e["properties"]["$ai_trace_id"]
+        finally:
+            os.unlink(path)
+
     def test_slash_command_without_prompt_id(self):
         entries = [
             {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -256,6 +256,73 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
+    def test_thinking_preserved_when_split_across_chunks(self):
+        """Regression coverage for #55 Defect 2: streaming entries can
+        split content blocks across chunks (e.g. thinking on chunk 1,
+        tool_use on chunk 2). The merge must preserve both."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "think then act"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            # Chunk 1: thinking only
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": None,
+                    "usage": {},
+                    "content": [{"type": "thinking", "thinking": "deep thoughts"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            # Chunk 2: tool_use only, complete usage
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 10, "output_tokens": 20, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                    "content": [{"type": "tool_use", "id": "t-1", "name": "Bash", "input": {"cmd": "ls"}}],
+                },
+                "timestamp": "2026-04-12T10:00:02.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert len(parsed["generations"]) == 1
+            gen = parsed["generations"][0]
+
+            # Both the thinking text and the tool_use survived
+            assert gen["output_text"] == "deep thoughts"
+            assert len(gen["tool_use_blocks"]) == 1
+            assert gen["tool_use_blocks"][0]["name"] == "Bash"
+
+            # Latest non-empty metadata wins
+            assert gen["stop_reason"] == "tool_use"
+            assert gen["input_tokens"] == 10
+            assert gen["output_tokens"] == 20
+
+            # Tool use is registered for span emission
+            assert len(parsed["tool_uses"]) == 1
+            assert parsed["tool_uses"][0]["name"] == "Bash"
+
+            # Downstream events include thinking in output_choices
+            events = build_events(parsed, DEFAULT_CONFIG)
+            gen_ev = next(e for e in events if e["event"] == "$ai_generation")
+            content_blocks = gen_ev["properties"]["$ai_output_choices"][0]["content"]
+            text_blocks = [b for b in content_blocks if b.get("type") == "text"]
+            assert text_blocks and "deep thoughts" in text_blocks[0]["text"]
+        finally:
+            os.unlink(path)
+
     def test_session_id_extracted_from_agent_sdk_jsonl(self):
         """Regression coverage for #55 Defect 1: Claude Agent SDK JSONLs
         don't emit a permission-mode entry, but every entry carries

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -393,6 +393,234 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
+    def test_session_id_prefers_permission_mode_when_present(self):
+        """When both permission-mode and other entries carry sessionId,
+        permission-mode wins (it's the canonical source). Guards against
+        accidentally picking up a sessionId from a malformed entry first."""
+        entries = [
+            # Pre-permission-mode user entry with a different sessionId
+            # (shouldn't happen in practice, but pin the precedence rule)
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "isMeta": True,
+                "message": {"role": "user", "content": ""},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "early-stray-id",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "canonical-id"},
+            {
+                "type": "user", "uuid": "u-2", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "hi"},
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "canonical-id",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-2",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 10},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                "timestamp": "2026-04-12T10:00:02.000Z",
+                "sessionId": "canonical-id",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert parsed["session_id"] == "canonical-id"
+        finally:
+            os.unlink(path)
+
+    def test_missing_session_id_returns_empty_without_crashing(self):
+        """A JSONL with no sessionId anywhere parses cleanly and leaves
+        session_id as empty string (rather than crashing)."""
+        entries = [
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "hi"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 10},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert parsed["session_id"] == ""
+            assert len(parsed["generations"]) == 1
+        finally:
+            os.unlink(path)
+
+    def test_three_chunk_merge_preserves_all_block_types(self):
+        """Thinking, text, and tool_use arriving in three separate chunks
+        all survive the merge."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "do stuff"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": None,
+                    "usage": {},
+                    "content": [{"type": "thinking", "thinking": "ponder"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": None,
+                    "usage": {},
+                    "content": [{"type": "text", "text": "here goes"}],
+                },
+                "timestamp": "2026-04-12T10:00:02.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 10, "output_tokens": 20},
+                    "content": [{"type": "tool_use", "id": "t-1", "name": "Bash", "input": {}}],
+                },
+                "timestamp": "2026-04-12T10:00:03.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert len(parsed["generations"]) == 1
+            gen = parsed["generations"][0]
+            assert "ponder" in gen["output_text"]
+            assert "here goes" in gen["output_text"]
+            assert len(gen["tool_use_blocks"]) == 1
+            assert gen["stop_reason"] == "tool_use"
+            assert gen["input_tokens"] == 10
+        finally:
+            os.unlink(path)
+
+    def test_cumulative_text_streaming_keeps_only_latest(self):
+        """When the same content type arrives in two chunks (cumulative
+        streaming — chunk 2 carries a longer/extended version of chunk 1),
+        the later chunk replaces the earlier and no duplicate appears."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "tell me"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": None,
+                    "usage": {},
+                    "content": [{"type": "text", "text": "Hello"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 15},
+                    "content": [{"type": "text", "text": "Hello, world."}],
+                },
+                "timestamp": "2026-04-12T10:00:02.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert len(parsed["generations"]) == 1
+            assert parsed["generations"][0]["output_text"] == "Hello, world."
+        finally:
+            os.unlink(path)
+
+    def test_delta_tool_use_across_chunks_known_limitation(self):
+        """Pin current behaviour: if tool_use blocks arrive split delta-style
+        ([A] then [B] for the same msg_id), the later chunk replaces the
+        earlier one rather than unioning. Claude Code's wire format is
+        cumulative for tool_use, so this case shouldn't arise in practice
+        — but if that ever changes, this test will surface it."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "do two things"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": None,
+                    "usage": {},
+                    "content": [{"type": "tool_use", "id": "t-A", "name": "Bash", "input": {}}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 5, "output_tokens": 15},
+                    "content": [{"type": "tool_use", "id": "t-B", "name": "Read", "input": {}}],
+                },
+                "timestamp": "2026-04-12T10:00:02.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert len(parsed["generations"]) == 1
+            tool_names = [tu["name"] for tu in parsed["tool_uses"]]
+            # Current behaviour: only the last chunk's tool_use survives.
+            # If this changes (e.g. we move to id-keyed union), revisit
+            # event_builder.py's $insert_id derivation for tool spans.
+            assert tool_names == ["Read"]
+        finally:
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # build_events
@@ -529,6 +757,74 @@ class TestBuildEvents:
             ids_a = sorted(e["properties"]["$insert_id"] for e in events_a)
             ids_b = sorted(e["properties"]["$insert_id"] for e in events_b)
             assert ids_a == ids_b
+        finally:
+            os.unlink(path)
+
+    def test_insert_id_differs_across_sessions(self):
+        """Guards against over-deduping: two different sessions with
+        identical msg_ids (rare but possible — Anthropic msg_ids aren't
+        guaranteed globally unique) must produce different $insert_ids."""
+        entries_a = _make_session([{"prompt": "x", "tools": []}])
+        entries_b = []
+        for entry in _make_session([{"prompt": "x", "tools": []}]):
+            new = dict(entry)
+            if "sessionId" in new:
+                new["sessionId"] = "different-session-id"
+            if new.get("type") == "permission-mode":
+                new["sessionId"] = "different-session-id"
+            entries_b.append(new)
+
+        path_a = _write_jsonl(entries_a)
+        path_b = _write_jsonl(entries_b)
+        try:
+            events_a = build_events(parse_session(path_a, DEFAULT_CONFIG), DEFAULT_CONFIG)
+            events_b = build_events(parse_session(path_b, DEFAULT_CONFIG), DEFAULT_CONFIG)
+            ids_a = {e["properties"]["$insert_id"] for e in events_a}
+            ids_b = {e["properties"]["$insert_id"] for e in events_b}
+            assert ids_a.isdisjoint(ids_b), \
+                "Different sessions must not share $insert_id"
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+
+    def test_insert_id_falls_back_to_span_id_when_msg_id_missing(self):
+        """Pin current limitation: if the assistant message has no `id`
+        field, the $insert_id derivation falls back to the parser's
+        span_id (which is a fresh uuid4 per parse). PostHog cannot dedupe
+        re-sends in that case. If this becomes a real problem we'd need
+        a different stable identifier (entry uuid + timestamp, say)."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "hi"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    # No "id" field on the assistant message
+                    "role": "assistant",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 10},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            events_a = build_events(parse_session(path, DEFAULT_CONFIG), DEFAULT_CONFIG)
+            events_b = build_events(parse_session(path, DEFAULT_CONFIG), DEFAULT_CONFIG)
+            gen_a = next(e for e in events_a if e["event"] == "$ai_generation")
+            gen_b = next(e for e in events_b if e["event"] == "$ai_generation")
+            # Known limitation: insert_id is NOT stable when msg_id is missing.
+            # If we ever change the fallback to use entry_uuid, flip this
+            # assertion to assertEqual.
+            assert gen_a["properties"]["$insert_id"] != gen_b["properties"]["$insert_id"]
         finally:
             os.unlink(path)
 

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -468,6 +468,55 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
+    def test_merge_preserves_first_seen_block_order(self):
+        """Regression coverage for codex review on PR #86:
+        _finalize_generation must not impose a fixed thinking → text →
+        tool_use order. If a chunk arrives text-first, output should
+        reflect that order rather than reshuffling by type."""
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "go"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            # Chunk 1: text first
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": None,
+                    "usage": {},
+                    "content": [{"type": "text", "text": "preface"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            # Chunk 2: thinking arrives after text
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 10},
+                    "content": [{"type": "thinking", "thinking": "afterthought"}],
+                },
+                "timestamp": "2026-04-12T10:00:02.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            assert len(parsed["generations"]) == 1
+            # Text came first in the source, so output_text must lead
+            # with "preface" rather than reshuffling thinking ahead of it.
+            assert parsed["generations"][0]["output_text"] == "preface\nafterthought"
+        finally:
+            os.unlink(path)
+
     def test_three_chunk_merge_preserves_all_block_types(self):
         """Thinking, text, and tool_use arriving in three separate chunks
         all survive the merge."""

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -10,7 +10,7 @@ import pytest
 # Add plugin root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from posthog_llma.parser import parse_session
+from posthog_llma.parser import parse_session, find_session_log
 from posthog_llma.event_builder import build_events
 from posthog_llma.config import load_config
 from posthog_llma.trace_naming import find_trace_name, clean_trace_name
@@ -145,6 +145,60 @@ def _make_session(prompts_and_tools=None) -> list[dict]:
             })
 
     return entries
+
+
+# ---------------------------------------------------------------------------
+# find_session_log
+# ---------------------------------------------------------------------------
+
+
+class TestFindSessionLog:
+    """Regression coverage for #48 and follow-ups (Windows backslash/colon,
+    underscores, spaces). Claude Code's project dir name collapses many
+    characters; we use a glob fallback rather than mirror its rules."""
+
+    def _stub_projects_dir(self, monkeypatch, tmp_path):
+        projects = tmp_path / ".claude" / "projects"
+        projects.mkdir(parents=True)
+        monkeypatch.setattr("posthog_llma.parser.Path.home", lambda: tmp_path)
+        return projects
+
+    def test_direct_lookup_still_works(self, monkeypatch, tmp_path):
+        projects = self._stub_projects_dir(monkeypatch, tmp_path)
+        (projects / "-Users-test-myproject").mkdir()
+        sid = "11111111-1111-1111-1111-111111111111"
+        log = projects / "-Users-test-myproject" / f"{sid}.jsonl"
+        log.write_text("{}")
+        assert find_session_log(sid, "/Users/test/myproject") == str(log)
+
+    def test_glob_fallback_handles_dots(self, monkeypatch, tmp_path):
+        projects = self._stub_projects_dir(monkeypatch, tmp_path)
+        # cwd contains a dot; Claude Code stores under dot-collapsed name
+        (projects / "-Users-me-dev--claude-worktrees-feature").mkdir()
+        sid = "22222222-2222-2222-2222-222222222222"
+        log = projects / "-Users-me-dev--claude-worktrees-feature" / f"{sid}.jsonl"
+        log.write_text("{}")
+        assert find_session_log(sid, "/Users/me/dev/.claude/worktrees/feature") == str(log)
+
+    def test_glob_fallback_handles_windows_path(self, monkeypatch, tmp_path):
+        projects = self._stub_projects_dir(monkeypatch, tmp_path)
+        (projects / "c--Users-me-PYProjs-my-project").mkdir()
+        sid = "33333333-3333-3333-3333-333333333333"
+        log = projects / "c--Users-me-PYProjs-my-project" / f"{sid}.jsonl"
+        log.write_text("{}")
+        assert find_session_log(sid, r"c:\Users\me\PYProjs\my-project") == str(log)
+
+    def test_glob_fallback_handles_underscores_and_spaces(self, monkeypatch, tmp_path):
+        projects = self._stub_projects_dir(monkeypatch, tmp_path)
+        (projects / "-Users-me-00-Projects-Project-Name").mkdir()
+        sid = "44444444-4444-4444-4444-444444444444"
+        log = projects / "-Users-me-00-Projects-Project-Name" / f"{sid}.jsonl"
+        log.write_text("{}")
+        assert find_session_log(sid, "/Users/me/00_Projects/Project Name") == str(log)
+
+    def test_returns_none_when_not_found(self, monkeypatch, tmp_path):
+        self._stub_projects_dir(monkeypatch, tmp_path)
+        assert find_session_log("nonexistent-uuid", "/some/path") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four bug fixes against the Claude Code SessionEnd ingest path, one commit per fix. Surfaced together because they collectively explain most of the open ingest reports.

| Commit | Issue | Symptom |
|---|---|---|
| `glob fallback in find_session_log` | #48 (+ Windows / underscore / space variants in thread) | Sessions silently dropped when cwd contains `.`, `\`, `:`, `_`, or space |
| `deterministic dedup key (top-level uuid)` | #85 | SessionEnd re-fires (after `claude --resume`) produced duplicate events; inflated tokens / cost / error rates |
| `session_id from any entry` | #55 (Defect 1) | Claude Agent SDK sessions ingested with empty `$ai_session_id` / `$ai_trace_id` |
| `merge content blocks per msg_id` | #55 (Defect 2) | Thinking blocks dropped when split across streaming chunks |

All four are diagnosed from the plugin source against detailed repro / verification posted in the issue threads (thanks @daptify, @madrussa, @aaronphua-git, @mory91).

### Note on the #85 dedup mechanism

First pass set `properties.$insert_id` and assumed PostHog would dedupe on it. Empirical verification against project 2 showed that did **not** dedupe — both sends landed as separate events with the same `$insert_id` property but distinct server-assigned `uuid`s.

PostHog's `/batch` ingest path dedupes on the event-level **`uuid`** field (the `events` table is a ClickHouse `ReplacingMergeTree` keyed by uuid); `$insert_id` as a property is not a dedup signal on this path. The fix now sets both — a deterministic UUIDv5 as the top-level `uuid` (the actual dedup key) and the same value mirrored into `properties.$insert_id` (visible in the UI as a debug marker).

End-to-end verification: two sends of the same session JSONL → 4 events submitted on the wire → 2 rows stored in clickhouse (1 generation + 1 trace, deduped). Same test pattern pre-fix landed 4 rows.

### Bonus: dev test helper

`scripts/dev_test_session.py` — small CLI for running a Claude Code session against the local (or remote-branch) build of this plugin, with the marketplace plugin temporarily disabled so SessionEnd doesn't double-fire. Mostly intended for verifying ingest fixes like the ones in this PR.

### Not addressed here

- #77 (SessionEnd doesn't fire under sandboxed/orchestrated runs) — design decision, needs an opt-in `POSTHOG_LLMA_FLUSH_ON=stop` env var rather than a bug fix. Worth a separate PR. With #85's deterministic dedup key landed, flush-on-Stop becomes safe — every turn can re-emit without producing duplicates.

## Test plan

- [x] `python3 -m pytest tests/` → 70 passed (was 51)
- [x] New regression coverage:
  - `TestFindSessionLog`: dots, Windows backslash+colon, underscores, spaces (#48)
  - `test_insert_id_set_on_all_events` (asserts top-level uuid == $insert_id), `test_insert_id_stable_across_reparses`, `test_insert_id_stable_in_message_mode`, `test_dedup_key_survives_send_batch` (sender-level uuid passthrough) (#85)
  - `test_session_id_extracted_from_agent_sdk_jsonl` (#55a)
  - `test_thinking_preserved_when_split_across_chunks` (#55b)
- [x] End-to-end dedup verified against PostHog project 2 — second send of the same session JSONL produced no new clickhouse rows