### PR TITLE
fix(phai): make MCP exec write-gate hook work on Codex

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Codex",
   "author": {
     "name": "PostHog",

--- a/hooks/gate-exec-write.sh
+++ b/hooks/gate-exec-write.sh
@@ -23,6 +23,16 @@
 
 set -u
 
+# Codex compatibility: Codex's PreToolUse protocol does not support
+# `permissionDecision: "ask"` (it is parsed then rejected as unsupported), and
+# Codex already gates tool calls through its own approval flow. Detect Codex via
+# its native PLUGIN_ROOT env var — Claude Code only ever sets CLAUDE_PLUGIN_ROOT,
+# never PLUGIN_ROOT — and skip the gate so the hook neither errors nor fights
+# Codex's prompt. See https://developers.openai.com/codex/hooks
+if [[ -n "${PLUGIN_ROOT:-}" ]]; then
+    exit 0
+fi
+
 input="$(cat)"
 
 # Extract `tool_name` — simple identifier, no escaping inside the value.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session-end-llma.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/hooks/session-end-llma.py",
             "timeout": 30
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gate-exec-write.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/hooks/gate-exec-write.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Problem

The PostHog plugin's `PreToolUse` write-gate (`hooks/gate-exec-write.sh`) is shared with Codex, which auto-discovers `hooks/hooks.json` in the plugin root. On Codex it failed twice in a row:

1. **`exited with code 127`** — the hook command used `${CLAUDE_PLUGIN_ROOT}`, which Codex does not set (its native variable is `PLUGIN_ROOT`). The shell expanded it to empty, so the command became `/hooks/gate-exec-write.sh` → command not found.
2. **`returned unsupported permissionDecision:ask`** — once the path resolved, the script emitted `permissionDecision:"ask"`, which Codex's `PreToolUse` protocol parses but rejects (only `allow`/`deny` are honored).

## Changes

- `hooks.json`: resolve the plugin root via `${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}` for both the `PreToolUse` and `SessionEnd` commands, so the path works on Codex while `CLAUDE_PLUGIN_ROOT` still wins on Claude Code.
- `gate-exec-write.sh`: skip the gate when running under Codex (detected via its native `PLUGIN_ROOT`, which Claude Code never sets). This is safe — Codex gates tool calls through its own approval flow, so the write-confirmation prompt isn't needed there.

Claude Code behavior is unchanged: write `call`s still prompt with `ask`, read-only calls pass through.

## How did you test this code?

Ran `gate-exec-write.sh` against both environments with a write (`call experiment-update`) and a read (`search`) payload:

- **Codex** (`PLUGIN_ROOT` set, `CLAUDE_PLUGIN_ROOT` unset): both exit 0 with no output — no more 127 / unsupported-decision errors.
- **Claude Code** (`CLAUDE_PLUGIN_ROOT` set): write → `permissionDecision:"ask"`, read → silent, exit 0.

Both copies pass `bash -n`. Also verified live in Claude Code via `--plugin-dir`.

## Publish to changelog?

no