### PR TITLE
feat(phai): gate PostHog MCP exec writes behind approval on Codex

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -22,6 +22,7 @@
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/codex-hooks.json",
   "interface": {
     "displayName": "PostHog",
     "shortDescription": "Analytics, feature flags, experiments, and error tracking",

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,8 @@
       "url": "https://mcp.posthog.com/mcp",
       "headers": {
         "x-posthog-mcp-consumer": "plugin"
-      }
+      },
+      "default_tools_approval_mode": "prompt"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add man
     /plugins
     ```
 
+3. Trust the write-approval hook:
+    ```
+    # In Codex, run /hooks, review the PostHog PermissionRequest hook, and trust it
+    /hooks
+    ```
+    The plugin asks for approval before `exec` calls that **modify** PostHog data (create, update, delete, …) while letting reads run uninterrupted. A freshly installed plugin hook is untrusted and does not run until you trust it — Codex prints a startup warning pointing you to `/hooks`. You only need to re-trust if the hook definition itself changes (not on plugin version bumps). Opt specific write tools out of the prompt with `POSTHOG_MCP_EXEC_GATE_ALLOW` — a comma-separated list of glob patterns matched against the PostHog tool name, e.g. `export POSTHOG_MCP_EXEC_GATE_ALLOW="annotation-create,llma-skill-*"`.
+
 ### Gemini CLI
 
 ```bash

--- a/hooks/codex-gate-exec-write.sh
+++ b/hooks/codex-gate-exec-write.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PermissionRequest gate for the PostHog MCP `exec` tool on Codex.
+#
+# Codex runs the posthog MCP server in `prompt` approval mode (see
+# `default_tools_approval_mode` in .mcp.json), so by default EVERY `exec` call
+# reaches an approval prompt. This hook narrows that to write `call`s only,
+# mirroring the Claude Code gate (hooks/gate-exec-write.sh):
+#
+#   - read / meta verbs (tools, search, info, schema), read `call`s, and
+#     allow-listed writes  -> return `allow` (suppresses the prompt)
+#   - write `call`s                                  -> no decision (defer), so
+#     Codex's prompt fires
+#   - unparseable `call`s                            -> no decision (defer), to
+#     fail safe toward asking
+#
+# Unlike the Claude gate, reads must be explicitly allowed: under `prompt` mode
+# a no-decision return would itself surface a prompt. The decision verbs are
+# `allow` / `deny` only — there is no `ask`; "ask" is the absence of a decision
+# combined with prompt mode. See https://developers.openai.com/codex/hooks
+#
+# Users can opt specific write tools out of the prompt via
+# `POSTHOG_MCP_EXEC_GATE_ALLOW` (same syntax as the Claude gate).
+#
+# Pure bash; no jq. Output is kept to `hookEventName` + `decision.behavior`
+# only: Codex denies unknown fields and fails closed on the reserved
+# `updatedInput`/`updatedPermissions`/`interrupt` fields.
+
+set -u
+
+# shellcheck source=hooks/lib-exec-gate.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-exec-gate.sh"
+
+# Return an `allow` decision and stop (prompt suppressed).
+allow() {
+    printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+    exit 0
+}
+
+# Emit no decision and stop — defer to Codex's normal approval flow. Under
+# prompt mode this means the user is asked.
+defer() {
+    exit 0
+}
+
+input="$(cat)"
+
+# Only gate the umbrella exec tool; if the matcher ever feeds us anything else,
+# don't interfere.
+tool_name="$(posthog_extract_tool_name "$input")"
+[[ "$tool_name" =~ __exec$ ]] || allow
+
+# Non-`call` verbs (tools/search/info/schema) are read-only metadata.
+verb="$(posthog_extract_verb "$input")"
+[[ "$verb" == "call" ]] || allow
+
+# It is a `call`: a write defers to the prompt (unless allow-listed); a read
+# `call` is allowed; an unparseable tool name fails safe to the prompt.
+posthog_tool="$(posthog_extract_call_tool "$input")"
+[[ -n "$posthog_tool" ]] || defer
+
+if posthog_is_write "$posthog_tool"; then
+    posthog_is_allowlisted "$posthog_tool" && allow
+    defer
+fi
+
+allow

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "__exec$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/hooks/codex-gate-exec-write.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/gate-exec-write.sh
+++ b/hooks/gate-exec-write.sh
@@ -17,62 +17,42 @@
 #
 #     export POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*,annotation-create"
 #
-# Pure bash; no jq or other third-party tools required. Relies on the fact
-# that PostHog tool names are kebab-case alphanumerics, so a narrow regex on
-# the raw JSON payload is safe.
+# Pure bash; no jq or other third-party tools required. Write-verb matching and
+# payload parsing live in hooks/lib-exec-gate.sh, shared with the Codex gate.
 
 set -u
 
 # Codex compatibility: Codex's PreToolUse protocol does not support
 # `permissionDecision: "ask"` (it is parsed then rejected as unsupported), and
-# Codex already gates tool calls through its own approval flow. Detect Codex via
-# its native PLUGIN_ROOT env var — Claude Code only ever sets CLAUDE_PLUGIN_ROOT,
-# never PLUGIN_ROOT — and skip the gate so the hook neither errors nor fights
-# Codex's prompt. See https://developers.openai.com/codex/hooks
+# Codex gates `exec` writes through its own PermissionRequest hook
+# (hooks/codex-gate-exec-write.sh). Detect Codex via its native PLUGIN_ROOT env
+# var — Claude Code only ever sets CLAUDE_PLUGIN_ROOT, never PLUGIN_ROOT — and
+# skip this gate so the hook neither errors nor fights Codex's prompt.
+# See https://developers.openai.com/codex/hooks
 if [[ -n "${PLUGIN_ROOT:-}" ]]; then
     exit 0
 fi
 
-input="$(cat)"
+# shellcheck source=hooks/lib-exec-gate.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-exec-gate.sh"
 
-# Extract `tool_name` — simple identifier, no escaping inside the value.
-tool_name=""
-if [[ "$input" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
-    tool_name="${BASH_REMATCH[1]}"
-fi
+input="$(cat)"
 
 # Match any MCP tool whose name ends in `__exec` regardless of plugin/server
 # namespacing (bare `mcp__posthog__exec` or plugin-prefixed variants like
 # `mcp__posthog_posthog__exec`).
+tool_name="$(posthog_extract_tool_name "$input")"
 [[ "$tool_name" =~ __exec$ ]] || exit 0
 
-# Extract the PostHog tool name from `"command":"call [--json] <tool>..."`.
-# Tool names are kebab-case [a-zA-Z0-9_-]+ so the regex stops cleanly at the
-# first space or escaped quote without needing to parse the trailing JSON.
-posthog_tool=""
-if [[ "$input" =~ \"command\"[[:space:]]*:[[:space:]]*\"call[[:space:]]+(--json[[:space:]]+)?([a-zA-Z0-9_-]+) ]]; then
-    posthog_tool="${BASH_REMATCH[2]}"
-fi
+# Only write `call`s are gated; reads and non-`call` verbs fall through.
+posthog_tool="$(posthog_extract_call_tool "$input")"
 [[ -n "$posthog_tool" ]] || exit 0
 
-# Match write-verb fragments as whole hyphen-separated words within the tool
-# name. Keep this list in sync with the PostHog MCP write surface.
-write_re='(^|-)(archive|cancel|create|delete|destroy|disable|duplicate|enable|end|invocations|launch|materialize|merge|move|partial-update|pause|rearrange|reload|rename|reorder|reset|restore|resume|resync|retry|set|ship|unarchive|unmaterialize|update)(-|$)'
+if posthog_is_write "$posthog_tool"; then
+    # User-controlled allowlist — skip the prompt for matching tools.
+    posthog_is_allowlisted "$posthog_tool" && exit 0
 
-shopt -s nocasematch
-if [[ "$posthog_tool" =~ $write_re ]]; then
-    # User-controlled allowlist — skip the prompt for tools matching any glob
-    # in POSTHOG_MCP_EXEC_GATE_ALLOW. Patterns use bash glob syntax (`*`, `?`).
-    if [[ -n "${POSTHOG_MCP_EXEC_GATE_ALLOW:-}" ]]; then
-        IFS=',' read -ra _allow_patterns <<< "$POSTHOG_MCP_EXEC_GATE_ALLOW"
-        for _pat in "${_allow_patterns[@]}"; do
-            _pat="${_pat#"${_pat%%[![:space:]]*}"}"
-            _pat="${_pat%"${_pat##*[![:space:]]}"}"
-            [[ -n "$_pat" && "$posthog_tool" == $_pat ]] && exit 0
-        done
-    fi
-
-    # `posthog_tool` is restricted to [a-zA-Z0-9_-]+ by the regex above, so
+    # `posthog_tool` is restricted to [a-zA-Z0-9_-]+ by the parser, so
     # interpolating it into the JSON response is safe — no characters that
     # would need escaping for JSON or printf.
     printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"`%s` modifies PostHog data — approve to run."}}' "$posthog_tool"

--- a/hooks/lib-exec-gate.sh
+++ b/hooks/lib-exec-gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shared helpers for the PostHog MCP `exec` write-gate hooks.
+#
+# Sourced (not executed) by both client gates so the write-verb surface and the
+# exec-payload parsing live in exactly one place and never drift:
+#   - hooks/gate-exec-write.sh        (Claude Code, PreToolUse)
+#   - hooks/codex-gate-exec-write.sh  (Codex, PermissionRequest)
+#
+# Pure bash; no jq or other third-party tools. PostHog tool names are kebab-case
+# alphanumerics, so narrow regexes on the raw JSON payload are safe.
+
+# Write-verb fragments matched as whole hyphen-separated words within a PostHog
+# tool name. Keep this list in sync with the PostHog MCP write surface.
+POSTHOG_WRITE_RE='(^|-)(archive|cancel|create|delete|destroy|disable|duplicate|enable|end|invocations|launch|materialize|merge|move|partial-update|pause|rearrange|reload|rename|reorder|reset|restore|resume|resync|retry|set|ship|unarchive|unmaterialize|update)(-|$)'
+
+# Echo the `tool_name` from a hook JSON payload (empty if absent). The value is
+# a simple identifier with no escaping inside it.
+posthog_extract_tool_name() {
+    local input="$1"
+    if [[ "$input" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    fi
+}
+
+# Echo the leading verb of the exec `command` (e.g. `call`, `tools`, `search`,
+# `info`, `schema`); empty if no `command` is present.
+posthog_extract_verb() {
+    local input="$1"
+    if [[ "$input" =~ \"command\"[[:space:]]*:[[:space:]]*\"([a-zA-Z0-9_-]+) ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    fi
+}
+
+# Echo the PostHog tool name from a `"command":"call [--json] <tool> ..."`
+# payload; empty if the command is not a `call` or the tool can't be parsed.
+# Tool names are [a-zA-Z0-9_-]+ so the regex stops cleanly at the first space.
+posthog_extract_call_tool() {
+    local input="$1"
+    if [[ "$input" =~ \"command\"[[:space:]]*:[[:space:]]*\"call[[:space:]]+(--json[[:space:]]+)?([a-zA-Z0-9_-]+) ]]; then
+        printf '%s' "${BASH_REMATCH[2]}"
+    fi
+}
+
+# Return 0 if the PostHog tool name denotes a write operation. Case-insensitive.
+posthog_is_write() {
+    local tool="$1" rc restore
+    restore="$(shopt -p nocasematch)"
+    shopt -s nocasematch
+    [[ "$tool" =~ $POSTHOG_WRITE_RE ]]
+    rc=$?
+    eval "$restore"
+    return "$rc"
+}
+
+# Return 0 if the tool matches any glob in POSTHOG_MCP_EXEC_GATE_ALLOW — a
+# comma-separated list of bash glob patterns (`*`, `?`). Case-insensitive.
+posthog_is_allowlisted() {
+    local tool="$1" pat rc=1 restore patterns
+    [[ -n "${POSTHOG_MCP_EXEC_GATE_ALLOW:-}" ]] || return 1
+    restore="$(shopt -p nocasematch)"
+    shopt -s nocasematch
+    local IFS=','
+    read -ra patterns <<< "$POSTHOG_MCP_EXEC_GATE_ALLOW"
+    for pat in "${patterns[@]}"; do
+        # Trim surrounding whitespace.
+        pat="${pat#"${pat%%[![:space:]]*}"}"
+        pat="${pat%"${pat##*[![:space:]]}"}"
+        if [[ -n "$pat" && "$tool" == $pat ]]; then
+            rc=0
+            break
+        fi
+    done
+    eval "$restore"
+    return "$rc"
+}


### PR DESCRIPTION
## Problem

The PostHog MCP exposes a single `exec` umbrella tool. Once a user allow-lists it on Codex, every dispatched **write** (`experiment-update`, `notebooks-destroy`, `cdp-functions-delete`, …) runs without a prompt. The existing Claude Code write-gate (`hooks/gate-exec-write.sh`) deliberately skips Codex because Codex's `PreToolUse` protocol rejects `permissionDecision: "ask"`, so on Codex there was no plugin-level write gate at all.

## Changes

Enforce **writes-only** approval on Codex, mirroring the Claude Code behavior. Codex's `PermissionRequest` hook can only `allow`/`deny`/defer (there is no "ask" verdict), so two pieces are needed:

- **`.mcp.json`** — put the `posthog` server in `prompt` approval mode (`default_tools_approval_mode`), so every `exec` call reaches the approval flow by default.
- **`hooks/codex-gate-exec-write.sh`** (new) + **`hooks/codex-hooks.json`** (new), registered via **`.codex-plugin/plugin.json`** — a `PermissionRequest` hook that returns `allow` for reads / meta verbs / allow-listed writes (suppressing the prompt) and defers writes so the prompt fires only on them.
- **`hooks/lib-exec-gate.sh`** (new) — extracts the write-verb regex and exec-payload parsing into one sourced helper, now used by both the Claude and Codex gates so the write surface can't drift. **Claude Code behavior is unchanged.**
- **README** — documents the one-time `/hooks` trust step on Codex and the `POSTHOG_MCP_EXEC_GATE_ALLOW` opt-out (works on both clients).

Note: a freshly installed plugin hook is untrusted on Codex and does not run until the user trusts it via `/hooks` (Codex prints a startup warning). The plugin sets `prompt` as a default; a user can still override it in their own config.

## How did you test this code?

- Unit-tested both gates by piping sample `PermissionRequest`/`PreToolUse` payloads through the scripts:
  - Codex gate → `allow` for meta verbs, read `call`s, non-exec tools, and allow-listed writes; **no decision** (defer → prompt) for write `call`s, allowlist mismatches, and unparseable `call`s.
  - Claude gate (regression) → `ask` only for non-allow-listed writes (incl. plugin-prefixed `mcp__posthog_posthog__exec`), silent otherwise, and still skips on Codex (`PLUGIN_ROOT` set).
- `jq` validation on all touched JSON; `bash -n` on all scripts.
- Remaining manual checks (need a live client): confirm Claude Code still connects the `posthog` MCP server with the new `.mcp.json` key, and that on Codex a read runs silently while a write prompts after trusting the hook.

## Publish to changelog?

no