### PR TITLE
docs: agent-neutral description + Grok install instructions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
+  "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from your AI coding tool. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
   "version": "1.1.37",
   "author": {
     "name": "PostHog",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add man
 gemini extensions install https://github.com/PostHog/ai-plugin
 ```
 
+### Grok
+
+1. Install the plugin:
+    ```bash
+    grok plugin install PostHog/ai-plugin --trust
+    ```
+
+2. Authenticate via OAuth:
+
+    On first use of a PostHog tool, Grok prompts you to authorize in your browser. Log into PostHog to connect.
+
 ## How to develop
 
 1. Clone and install the plugin:


### PR DESCRIPTION
## Problem

The plugin is being listed in the [xAI/Grok plugin marketplace](https://github.com/xai-org/plugin-marketplace) (catalog PR: https://github.com/xai-org/plugin-marketplace/pull/50). Grok's index reads `.claude-plugin/plugin.json` via fallback (same as Vercel and MongoDB, which are also multi-agent repos with no `.grok-plugin/`). Two small things read as Claude-only when surfaced in Grok:

- The `plugin.json` description says "directly from Claude Code".
- The README has install sections for Claude Code, Cursor, Codex, and Gemini CLI, but not Grok.

## Changes

- **`.claude-plugin/plugin.json`** — reword the description to "directly from your AI coding tool". The second sentence about capturing **Claude Code sessions** to LLM Analytics stays as-is, since that feature is genuinely Claude Code-only.
- **`README.md`** — add a **Grok** install section: `grok plugin install PostHog/ai-plugin --trust`, then OAuth-on-first-use (Grok prompts in the browser; matches how Vercel's marketplace plugin documents its OAuth flow).

No functional change — the MCP server, skills, commands, and hooks are untouched.

## How did you test this code

- `python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"` — manifest still parses.
- Install command verified against [`getsentry/plugin-grok`](https://github.com/getsentry/plugin-grok)'s README, which documents the same `grok plugin install <owner>/<repo> --trust` form.
- The xAI marketplace generator already indexed this plugin from the pinned commit (skills, MCP server, commands, hooks all detected).

## Changelog

No — docs/metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)