### PR TITLE
chore: migrate client getFeatureFlagPayload examples to getFeatureFlagResult

### DIFF
--- a/skills/instrument-feature-flags/references/adding-feature-flag-code.md
+++ b/skills/instrument-feature-flags/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1648,7 +1648,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1859,7 +1859,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -1874,7 +1874,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/instrument-feature-flags/references/android.md
+++ b/skills/instrument-feature-flags/references/android.md
@@ -88,7 +88,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if (enabledVariant == "variant-key") { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/instrument-feature-flags/references/flutter.md
+++ b/skills/instrument-feature-flags/references/flutter.md
@@ -154,7 +154,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 
@@ -175,7 +175,7 @@
     if (enabledVariant == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 

--- a/skills/instrument-feature-flags/references/ios.md
+++ b/skills/instrument-feature-flags/references/ios.md
@@ -88,7 +88,7 @@
     if isMyFlagEnabled {
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/instrument-feature-flags/references/react-native.md
+++ b/skills/instrument-feature-flags/references/react-native.md
@@ -105,7 +105,7 @@
         if (isMyFlagEnabled) {
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }
@@ -127,7 +127,7 @@
         if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }

--- a/skills/instrument-feature-flags/references/web.md
+++ b/skills/instrument-feature-flags/references/web.md
@@ -94,7 +94,7 @@
     if (posthog.isFeatureEnabled('flag-key')) {
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -110,7 +110,7 @@
     if (posthog.getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -123,7 +123,7 @@
     Feature flags can include payloads with additional data. Fetch the payload like this:
 
     ```javascript
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     ```
 
 6.  6

--- a/skills/instrument-integration/references/android.md
+++ b/skills/instrument-integration/references/android.md
@@ -444,7 +444,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -459,7 +459,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/instrument-integration/references/posthog-js.md
+++ b/skills/instrument-integration/references/posthog-js.md
@@ -1821,8 +1821,9 @@ Get feature flag payload value matching key for user (supports multivariate flag
 ### Examples
 
 ```ts
-if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
+const betaFeature = posthog.getFeatureFlagResult('beta-feature')
+if (betaFeature?.variant === 'some-value') {
+     const someValue = betaFeature?.payload
      // do something
 }
 ```

--- a/skills/instrument-integration/references/posthog-js.md
+++ b/skills/instrument-integration/references/posthog-js.md
@@ -1822,7 +1822,7 @@ Get feature flag payload value matching key for user (supports multivariate flag
 
 ```ts
 if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagPayload('beta-feature')
+     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
      // do something
 }
 ```

--- a/skills/instrument-integration/references/react-native.md
+++ b/skills/instrument-integration/references/react-native.md
@@ -712,7 +712,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/instrument-product-analytics/references/android.md
+++ b/skills/instrument-product-analytics/references/android.md
@@ -444,7 +444,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -459,7 +459,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/instrument-product-analytics/references/react-native.md
+++ b/skills/instrument-product-analytics/references/react-native.md
@@ -712,7 +712,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage


### PR DESCRIPTION
## Summary

Migrates the **client-side** `getFeatureFlagPayload(...)` examples in the feature-flag skill references to `getFeatureFlagResult(...)?.payload`, matching the deprecation now in effect across the client SDKs (browser, React Native, iOS, Android, Flutter). `getFeatureFlagResult` returns the flag value and payload from a single evaluation; the imperative `getFeatureFlagPayload` is deprecated in those SDKs.

Only client forms were changed:
- `posthog.getFeatureFlagPayload('…')` → `posthog.getFeatureFlagResult('…')?.payload`
- `await Posthog().getFeatureFlagPayload('…')` → `(await Posthog().getFeatureFlagResult('…'))?.payload`
- `PostHogSDK.shared.getFeatureFlagPayload("…")` → `PostHogSDK.shared.getFeatureFlagResult("…")?.payload`
- `PostHog.getFeatureFlagPayload("…")` → `PostHog.getFeatureFlagResult("…")?.payload`

**Left unchanged** (intentional): backend SDK forms that take a `distinctId` (Node `client.getFeatureFlagPayload(key, distinctId, …)`, Java, PHP `$posthog->`, etc.) — those follow the separate `evaluateFlags()` deprecation — plus the `array.js` loader stubs and prose/heading mentions.

> Note: these reference files appear to be **generated** (the same snippets are duplicated across many per-SDK skill directories). The upstream source on posthog.com has already been migrated, so the generator should reproduce this; this PR fixes the currently committed snapshots so AI agents reading them today get the non-deprecated API.
