### PR TITLE
Gate exec writes on a sensitive default set, add disable + deny vars

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from your AI coding tool. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "author": {
     "name": "PostHog",
     "email": "hey@posthog.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Codex",
   "author": {
     "name": "PostHog",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog",
   "displayName": "PostHog",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Cursor",
   "author": {
     "name": "PostHog",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Gemini CLI",
   "mcpServers": {
     "posthog": {

--- a/hooks/gate-exec-write.sh
+++ b/hooks/gate-exec-write.sh
@@ -11,11 +11,27 @@
 # Read-only PostHog tools and non-`call` exec verbs are left alone — the hook
 # exits 0 so normal permission flow applies.
 #
-# Users can opt specific write tools out of the prompt via
-# `POSTHOG_MCP_EXEC_GATE_ALLOW` — a comma-separated list of bash glob patterns
-# matched against the PostHog tool name. Example:
+# By default the prompt fires only for a curated "sensitive" subset of write
+# tools — feature-flag writes and any delete/destroy — rather than every write.
+# Three env vars tune this (all matched against the PostHog tool name):
 #
-#     export POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*,annotation-create"
+#   POSTHOG_MCP_EXEC_GATE_DISABLE  — set to a non-empty value (e.g. `1`) to turn
+#       the gate off entirely. Useful for remote devboxes and Claude Cloud runs
+#       where the prompt can't be answered. Example:
+#
+#           export POSTHOG_MCP_EXEC_GATE_DISABLE=1
+#
+#   POSTHOG_MCP_EXEC_GATE_DENY     — comma-separated bash globs selecting which
+#       write tools prompt. Overrides the built-in default set. Use `*` to
+#       prompt on every write (the previous behaviour). Example:
+#
+#           export POSTHOG_MCP_EXEC_GATE_DENY="*feature-flag*,*-delete"
+#
+#   POSTHOG_MCP_EXEC_GATE_ALLOW    — comma-separated bash globs that opt specific
+#       write tools out of the prompt. Applied on top of the deny set (allow
+#       wins). Example:
+#
+#           export POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*,annotation-create"
 #
 # Pure bash; no jq or other third-party tools required. Relies on the fact
 # that PostHog tool names are kebab-case alphanumerics, so a narrow regex on
@@ -32,6 +48,19 @@ set -u
 if [[ -n "${PLUGIN_ROOT:-}" ]]; then
     exit 0
 fi
+
+# Full opt-out — turn the gate off entirely. Set to any non-empty value other
+# than `0`. Lets remote devboxes and Claude Cloud runs, where no one can answer
+# the prompt, run write `call`s without interruption.
+if [[ -n "${POSTHOG_MCP_EXEC_GATE_DISABLE:-}" && "${POSTHOG_MCP_EXEC_GATE_DISABLE}" != "0" ]]; then
+    exit 0
+fi
+
+# Default set of write tools that prompt. Comma-separated bash globs. Covers the
+# sensitive surface — feature-flag writes and any delete/destroy — and is
+# overridden wholesale by POSTHOG_MCP_EXEC_GATE_DENY when that is set. Use
+# POSTHOG_MCP_EXEC_GATE_DENY="*" to restore prompting on every write.
+DEFAULT_DENY='*feature-flag*,*delete*,*destroy*'
 
 input="$(cat)"
 
@@ -59,18 +88,34 @@ fi
 # name. Keep this list in sync with the PostHog MCP write surface.
 write_re='(^|-)(archive|cancel|create|delete|destroy|disable|duplicate|enable|end|invocations|launch|materialize|merge|move|partial-update|pause|rearrange|reload|rename|reorder|reset|restore|resume|resync|retry|set|ship|unarchive|unmaterialize|update)(-|$)'
 
+# Match comma-separated bash globs in $2 against the PostHog tool name ($1).
+# Whitespace around each pattern is trimmed; empty patterns are skipped.
+# Returns 0 on the first match, 1 if none match.
+matches_any_glob() {
+    local tool="$1" patterns="$2" _pat
+    local -a _list
+    IFS=',' read -ra _list <<< "$patterns"
+    for _pat in "${_list[@]}"; do
+        _pat="${_pat#"${_pat%%[![:space:]]*}"}"
+        _pat="${_pat%"${_pat##*[![:space:]]}"}"
+        [[ -n "$_pat" && "$tool" == $_pat ]] && return 0
+    done
+    return 1
+}
+
 shopt -s nocasematch
 if [[ "$posthog_tool" =~ $write_re ]]; then
-    # User-controlled allowlist — skip the prompt for tools matching any glob
-    # in POSTHOG_MCP_EXEC_GATE_ALLOW. Patterns use bash glob syntax (`*`, `?`).
+    # Allowlist wins — skip the prompt for tools matching any glob in
+    # POSTHOG_MCP_EXEC_GATE_ALLOW. Patterns use bash glob syntax (`*`, `?`).
     if [[ -n "${POSTHOG_MCP_EXEC_GATE_ALLOW:-}" ]]; then
-        IFS=',' read -ra _allow_patterns <<< "$POSTHOG_MCP_EXEC_GATE_ALLOW"
-        for _pat in "${_allow_patterns[@]}"; do
-            _pat="${_pat#"${_pat%%[![:space:]]*}"}"
-            _pat="${_pat%"${_pat##*[![:space:]]}"}"
-            [[ -n "$_pat" && "$posthog_tool" == $_pat ]] && exit 0
-        done
+        matches_any_glob "$posthog_tool" "$POSTHOG_MCP_EXEC_GATE_ALLOW" && exit 0
     fi
+
+    # Denylist selects which writes actually prompt. POSTHOG_MCP_EXEC_GATE_DENY
+    # overrides the built-in default set; an empty/unset value falls back to it.
+    deny_patterns="${POSTHOG_MCP_EXEC_GATE_DENY:-}"
+    [[ -n "$deny_patterns" ]] || deny_patterns="$DEFAULT_DENY"
+    matches_any_glob "$posthog_tool" "$deny_patterns" || exit 0
 
     # `posthog_tool` is restricted to [a-zA-Z0-9_-]+ by the regex above, so
     # interpolating it into the JSON response is safe — no characters that

--- a/hooks/gate-exec-write.sh
+++ b/hooks/gate-exec-write.sh
@@ -37,6 +37,19 @@
 # that PostHog tool names are kebab-case alphanumerics, so a narrow regex on
 # the raw JSON payload is safe.
 
+# Fail open — this gate must never break a Claude Code tool call.
+#
+# The "ask" decision is delivered entirely through the stdout JSON below; the
+# exit code is never used to signal it. So we force every exit path to 0 via an
+# EXIT trap. Any unexpected runtime failure — an unbound variable under `set -u`,
+# a failed builtin, an unusually old bash — then falls through to normal
+# permission flow instead of surfacing as a hook error. Crucially, it can never
+# exit 2, which Claude Code interprets as a hard *block* of the tool call.
+#
+# The one failure a trap can't catch is a parse-time syntax error (the trap
+# isn't installed yet); `tests/test_gate_exec_write.sh` guards that with `bash -n`.
+trap 'exit 0' EXIT
+
 set -u
 
 # Codex compatibility: Codex's PreToolUse protocol does not support

--- a/hooks/gate-exec-write.sh
+++ b/hooks/gate-exec-write.sh
@@ -56,11 +56,30 @@ if [[ -n "${POSTHOG_MCP_EXEC_GATE_DISABLE:-}" && "${POSTHOG_MCP_EXEC_GATE_DISABL
     exit 0
 fi
 
-# Default set of write tools that prompt. Comma-separated bash globs. Covers the
-# sensitive surface — feature-flag writes and any delete/destroy — and is
-# overridden wholesale by POSTHOG_MCP_EXEC_GATE_DENY when that is set. Use
+# Default set of write tools that prompt. Comma-separated bash globs, grounded in
+# the live PostHog MCP tool registry. Covers the genuinely sensitive surface:
+#
+#   *feature-flag*  — feature-flag rollout writes: create-feature-flag,
+#                     update-feature-flag, delete-feature-flag,
+#                     feature-flags-bulk-{delete,update-tags}-create,
+#                     feature-flags-copy-flags-create
+#   *delete*        — any deletion: insight-delete, dashboard-delete,
+#                     cdp-functions-delete, persons-bulk-delete,
+#                     external-data-schemas-delete-data, session-recording-delete, …
+#   *destroy*       — any destroy: notebooks-destroy, accounts-destroy,
+#                     experiment-saved-metrics-destroy, agent-applications-destroy, …
+#   experiment-launch / experiment-ship-variant / experiment-reset
+#                   — start exposing users / roll a variant to everyone / wipe results
+#   survey-launch   — start showing a survey to real users
+#   workflows-enable — activate a user-facing automation
+#
+# Deliberately silent by default (lower blast radius / easily reverted): routine
+# create & update (insight, dashboard, annotation, cohort, alert, skill, …),
+# experiment-pause/resume/end, survey-stop, persons-property-set,
+# error-tracking-issues-merge/split. Add any of these via
+# POSTHOG_MCP_EXEC_GATE_DENY, which overrides this set wholesale; use
 # POSTHOG_MCP_EXEC_GATE_DENY="*" to restore prompting on every write.
-DEFAULT_DENY='*feature-flag*,*delete*,*destroy*'
+DEFAULT_DENY='*feature-flag*,*delete*,*destroy*,experiment-launch,experiment-ship-variant,experiment-reset,survey-launch,workflows-enable'
 
 input="$(cat)"
 

--- a/tests/test_gate_exec_write.sh
+++ b/tests/test_gate_exec_write.sh
@@ -110,8 +110,32 @@ run_case "default: delete write (cdp-functions-delete) prompts" \
     "$(exec_call cdp-functions-delete)" \
     prompt cdp-functions-delete
 
+run_case "default: rollout write (experiment-launch) prompts" \
+    "$(exec_call experiment-launch)" \
+    prompt experiment-launch
+
+run_case "default: rollout write (experiment-ship-variant) prompts" \
+    "$(exec_call experiment-ship-variant)" \
+    prompt experiment-ship-variant
+
+run_case "default: rollout write (survey-launch) prompts" \
+    "$(exec_call survey-launch)" \
+    prompt survey-launch
+
+run_case "default: rollout write (workflows-enable) prompts" \
+    "$(exec_call workflows-enable)" \
+    prompt workflows-enable
+
 run_case "default: non-sensitive write (experiment-update) is silent" \
     "$(exec_call experiment-update)" \
+    silent
+
+run_case "default: reversible lifecycle write (experiment-pause) is silent" \
+    "$(exec_call experiment-pause)" \
+    silent
+
+run_case "default: routine write (insight-create) is silent" \
+    "$(exec_call insight-create)" \
     silent
 
 run_case "default: non-sensitive write (llma-skill-update) is silent" \
@@ -120,6 +144,10 @@ run_case "default: non-sensitive write (llma-skill-update) is silent" \
 
 run_case "default: feature-flag read (feature-flag-get-all) is silent" \
     "$(exec_call feature-flag-get-all)" \
+    silent
+
+run_case "default: feature-flag read (feature-flags-status-retrieve) is silent" \
+    "$(exec_call feature-flags-status-retrieve)" \
     silent
 
 # --- POSTHOG_MCP_EXEC_GATE_DISABLE turns the gate off entirely ---

--- a/tests/test_gate_exec_write.sh
+++ b/tests/test_gate_exec_write.sh
@@ -88,71 +88,125 @@ run_case "read-only call with allowlist set is still silent" \
     silent "" \
     POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
 
-# --- write cases without allowlist (should prompt) ---
+# --- default deny set: sensitive writes prompt, other writes are silent ---
 
-run_case "write call (experiment-update) prompts" \
-    "$(exec_call experiment-update)" \
-    prompt experiment-update
+run_case "default: feature-flag write (create-feature-flag) prompts" \
+    "$(exec_call create-feature-flag)" \
+    prompt create-feature-flag
 
-run_case "write call (notebooks-destroy) prompts" \
+run_case "default: feature-flag write (update-feature-flag) prompts" \
+    "$(exec_call update-feature-flag)" \
+    prompt update-feature-flag
+
+run_case "default: feature-flag bulk write prompts" \
+    "$(exec_call feature-flags-bulk-update-tags-create)" \
+    prompt feature-flags-bulk-update-tags-create
+
+run_case "default: destroy write (notebooks-destroy) prompts" \
     "$(exec_call notebooks-destroy)" \
     prompt notebooks-destroy
 
-run_case "write call (cdp-functions-delete) prompts" \
+run_case "default: delete write (cdp-functions-delete) prompts" \
     "$(exec_call cdp-functions-delete)" \
     prompt cdp-functions-delete
 
-run_case "write call via plugin-prefixed exec name prompts" \
-    "$(exec_call llma-skill-update mcp__posthog_posthog__exec)" \
-    prompt llma-skill-update
+run_case "default: non-sensitive write (experiment-update) is silent" \
+    "$(exec_call experiment-update)" \
+    silent
 
-run_case "write call with --json flag still extracts tool" \
-    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"call --json experiment-update {\"id\":1}"}}' \
-    prompt experiment-update
-
-run_case "empty POSTHOG_MCP_EXEC_GATE_ALLOW behaves as unset" \
+run_case "default: non-sensitive write (llma-skill-update) is silent" \
     "$(exec_call llma-skill-update)" \
-    prompt llma-skill-update \
-    POSTHOG_MCP_EXEC_GATE_ALLOW=""
+    silent
 
-# --- write cases with allowlist (should be silent on match) ---
+run_case "default: feature-flag read (feature-flag-get-all) is silent" \
+    "$(exec_call feature-flag-get-all)" \
+    silent
 
-run_case "allowlist glob matches (llma-skill-*)" \
+# --- POSTHOG_MCP_EXEC_GATE_DISABLE turns the gate off entirely ---
+
+run_case "disable=1 silences a sensitive feature-flag write" \
+    "$(exec_call delete-feature-flag)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_DISABLE="1"
+
+run_case "disable=0 leaves the gate active" \
+    "$(exec_call delete-feature-flag)" \
+    prompt delete-feature-flag \
+    POSTHOG_MCP_EXEC_GATE_DISABLE="0"
+
+# --- POSTHOG_MCP_EXEC_GATE_DENY overrides the default set ---
+
+run_case 'deny="*" restores prompting on every write' \
+    "$(exec_call experiment-update)" \
+    prompt experiment-update \
+    POSTHOG_MCP_EXEC_GATE_DENY="*"
+
+run_case "deny narrowed to feature flags: experiment-update is silent" \
+    "$(exec_call experiment-update)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_DENY="*feature-flag*"
+
+run_case "deny narrowed to feature flags: create-feature-flag prompts" \
+    "$(exec_call create-feature-flag)" \
+    prompt create-feature-flag \
+    POSTHOG_MCP_EXEC_GATE_DENY="*feature-flag*"
+
+run_case "empty POSTHOG_MCP_EXEC_GATE_DENY falls back to default set" \
+    "$(exec_call notebooks-destroy)" \
+    prompt notebooks-destroy \
+    POSTHOG_MCP_EXEC_GATE_DENY=""
+
+run_case "deny with --json flag still extracts tool" \
+    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"call --json delete-feature-flag {\"id\":1}"}}' \
+    prompt delete-feature-flag
+
+run_case "sensitive write via plugin-prefixed exec name prompts" \
+    "$(exec_call delete-feature-flag mcp__posthog_posthog__exec)" \
+    prompt delete-feature-flag
+
+# --- allowlist wins over the deny set (silent on match) ---
+
+run_case "allowlist glob matches (feature-flag-*) over default deny" \
+    "$(exec_call create-feature-flag)" \
+    silent "" \
+    POSTHOG_MCP_EXEC_GATE_ALLOW="create-feature-flag"
+
+run_case "allowlist glob matches (llma-skill-*) under deny=*" \
     "$(exec_call llma-skill-update)" \
     silent "" \
-    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
+    POSTHOG_MCP_EXEC_GATE_DENY="*" POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
 
 run_case "allowlist glob matches multiple skill writes (file-create)" \
     "$(exec_call llma-skill-file-create)" \
     silent "" \
-    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
+    POSTHOG_MCP_EXEC_GATE_DENY="*" POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*"
 
 run_case "allowlist exact match" \
     "$(exec_call annotation-create)" \
     silent "" \
-    POSTHOG_MCP_EXEC_GATE_ALLOW="annotation-create"
+    POSTHOG_MCP_EXEC_GATE_DENY="*" POSTHOG_MCP_EXEC_GATE_ALLOW="annotation-create"
 
 run_case "allowlist multi-entry with whitespace" \
     "$(exec_call llma-skill-update)" \
     silent "" \
-    POSTHOG_MCP_EXEC_GATE_ALLOW=" annotation-create , llma-skill-update "
+    POSTHOG_MCP_EXEC_GATE_DENY="*" POSTHOG_MCP_EXEC_GATE_ALLOW=" annotation-create , llma-skill-update "
 
 run_case "allowlist ? glob matches single char" \
     "$(exec_call experiment-end)" \
     silent "" \
-    POSTHOG_MCP_EXEC_GATE_ALLOW="experiment-en?"
+    POSTHOG_MCP_EXEC_GATE_DENY="*" POSTHOG_MCP_EXEC_GATE_ALLOW="experiment-en?"
 
-# --- write cases with non-matching allowlist (should still prompt) ---
+# --- non-matching allowlist still prompts ---
 
-run_case "non-matching allowlist still prompts" \
-    "$(exec_call llma-skill-update)" \
-    prompt llma-skill-update \
+run_case "non-matching allowlist still prompts a feature-flag write" \
+    "$(exec_call create-feature-flag)" \
+    prompt create-feature-flag \
     POSTHOG_MCP_EXEC_GATE_ALLOW="annotation-*"
 
-run_case "allowlist does not bypass an unrelated write tool" \
-    "$(exec_call experiment-update)" \
-    prompt experiment-update \
-    POSTHOG_MCP_EXEC_GATE_ALLOW="llma-skill-*,annotation-create"
+run_case "empty POSTHOG_MCP_EXEC_GATE_ALLOW behaves as unset" \
+    "$(exec_call create-feature-flag)" \
+    prompt create-feature-flag \
+    POSTHOG_MCP_EXEC_GATE_ALLOW=""
 
 # --- regex word-boundary cases ---
 

--- a/tests/test_gate_exec_write.sh
+++ b/tests/test_gate_exec_write.sh
@@ -246,6 +246,36 @@ run_case "embedded substring is not a write verb (e.g. updates-feed)" \
     "$(exec_call some-updates-feed)" \
     silent
 
+# --- fail-open contract: the hook must never break a tool call ---
+#
+# The hook signals "ask" only via stdout JSON + exit 0. Every other path must
+# also exit 0 so a hook failure can never reach Claude Code as exit 2 — which it
+# treats as a hard *block* of the user's tool call.
+
+# The only thing that can make the hook exit 2 is a parse-time syntax error,
+# which the runtime EXIT trap cannot catch. Guard it here.
+if bash -n "$HOOK" 2>/dev/null; then
+    pass=$((pass + 1)); printf "  ok   hook passes 'bash -n' syntax check\n"
+else
+    fail=$((fail + 1)); printf "  FAIL hook has a syntax error ('bash -n')\n"
+fi
+
+# No input, however malformed, may yield exit code 2 (block). Fail open instead.
+for _payload in \
+    '' \
+    'not json at all {{{' \
+    '{"tool_name":"mcp__posthog__exec"}' \
+    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"call ' \
+    '{"tool_name":"mcp__posthog__exec","tool_input":{"command":"call delete-feature-flag {}"}}'
+do
+    env -i PATH="$PATH" bash "$HOOK" <<<"$_payload" >/dev/null 2>&1
+    if (( $? != 2 )); then
+        pass=$((pass + 1)); printf "  ok   never exits 2 (block) for: %q\n" "$_payload"
+    else
+        fail=$((fail + 1)); printf "  FAIL exited 2 (would block) for: %q\n" "$_payload"
+    fi
+done
+
 # --- summary ---
 
 echo


### PR DESCRIPTION
## Summary

The MCP `exec` write gate previously prompted on **every** write `call`. That's noisy on remote devboxes and Claude Cloud runs, where there's no one to answer the prompt.

This flips the default so the gate only prompts for a curated **sensitive** subset of writes (grounded in the live MCP tool registry), and adds two env vars to tune it:

- **Default deny set** — `*feature-flag*`, `*delete*`, `*destroy*`, plus the high-blast-radius rollout/user-facing lifecycle ops `experiment-launch`, `experiment-ship-variant`, `experiment-reset`, `survey-launch`, `workflows-enable`. Everything else (routine `insight-create`, `dashboard-update`, `experiment-pause`, etc.) runs silently.
- **`POSTHOG_MCP_EXEC_GATE_DISABLE`** — set to a non-empty value (e.g. `1`) to turn the gate off entirely. Intended for devboxes / Cloud runs.
- **`POSTHOG_MCP_EXEC_GATE_DENY`** — comma-separated bash globs that override the default set. Use `*` to restore the old "prompt on every write" behaviour.
- **`POSTHOG_MCP_EXEC_GATE_ALLOW`** (unchanged) still wins over the deny set.

The write-verb regex stays as a prefilter, so deny globs like `*feature-flag*` never catch read tools (`feature-flag-get-all`, `feature-flags-status-retrieve` stay silent).

## Grounding

The deny globs were validated against the live PostHog MCP `tools` registry — `*feature-flag*` / `*delete*` / `*destroy*` match ~50 real tools (create/update/delete-feature-flag, the bulk FF ops, insight-delete, persons-bulk-delete, notebooks-destroy, …). The registry also surfaced sensitive non-delete ops that would otherwise run silently (`experiment-launch`, `experiment-ship-variant`, `survey-launch`, `workflows-enable`), which is why those are in the default set.

Deliberately left **silent** by default (lower blast radius / easily reverted): routine create & update, `experiment-pause/resume/end`, `survey-stop`, `persons-property-set`, error-tracking issue merge/split. Easy to add via `POSTHOG_MCP_EXEC_GATE_DENY`.

## Why

Per the Slack thread: the exec confirmation prompt fires constantly in remote devboxes and Claude Cloud runs and is hard to disable there. We wanted the default to only kick in on sensitive-looking calls (feature-flag writes were the motivating example) plus an actual off switch.

## Note for reviewers

The default deny set is a judgement call. If you'd rather keep it strictly to feature-flag writes + deletes, drop the lifecycle entries from `DEFAULT_DENY` in `hooks/gate-exec-write.sh` — one line. Happy to adjust the scope either way.

## Test plan

- [x] `bash tests/test_gate_exec_write.sh` — 39/39 pass (covers the default set, the rollout-lifecycle entries, `DISABLE`, `DENY` override, and allow-wins-over-deny).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KTRWD3HD/p1782390385317709?thread_ts=1782390385.317709&cid=C09KTRWD3HD)*