### PR TITLE
feat(llma): emit git branch and repo on ai events

### DIFF
--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import uuid
 from datetime import datetime as dt
 from typing import Optional
@@ -12,6 +13,58 @@ from posthog_llma.trace_naming import find_trace_name
 # Stable namespace for deriving deterministic event UUIDs via uuid5.
 # Don't change — would break dedup against previously ingested events.
 _UUID_NAMESPACE = uuid.UUID("a3c3f6c2-9b8e-4a3e-b3a1-7e6b8e9a0f00")
+
+
+def parse_git_remote_url(url: str) -> Optional[str]:
+    """Extract `owner/name` from a git remote URL.
+
+    Handles the two common forms Claude Code sessions run under:
+      - ssh scp-like: `git@github.com:owner/name.git`
+      - https: `https://github.com/owner/name.git`
+    Returns None when the URL doesn't resolve to an `owner/name` pair.
+    """
+    url = (url or "").strip()
+    if not url:
+        return None
+    if url.endswith(".git"):
+        url = url[:-4]
+
+    if "://" in url:
+        # scheme://[user@]host/owner/name -> drop scheme + host
+        rest = url.split("://", 1)[1]
+        parts = rest.split("/", 1)
+        url = parts[1] if len(parts) > 1 else ""
+    elif ":" in url:
+        # scp-like git@host:owner/name -> drop host
+        url = url.split(":", 1)[1]
+
+    segments = [s for s in url.split("/") if s]
+    if len(segments) < 2:
+        return None
+    return "/".join(segments[-2:])
+
+
+def _git_repo_for_cwd(cwd: str) -> Optional[str]:
+    """Best-effort `owner/name` for the session's working directory.
+
+    Shells out to `git remote get-url origin` and parses the result. The
+    cwd may no longer exist by ingest time, so every failure is swallowed.
+    """
+    if not cwd:
+        return None
+
+    repo = None
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0:
+            repo = parse_git_remote_url(result.stdout)
+    except Exception:
+        repo = None
+
+    return repo
 
 
 def _insert_id(*parts: str) -> str:
@@ -63,6 +116,15 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
     session_id = parsed["session_id"]
     cwd = parsed["metadata"].get("cwd", "")
     project_name = os.path.basename(cwd) if cwd else ""
+
+    # Git context attached to every emitted event. Branch comes straight
+    # from the transcript; repo is derived at ingest time via a single
+    # `git remote get-url origin` shellout. Filtered to truthy values so
+    # a single `properties.update(git_properties)` is a no-op when unknown.
+    git_branch = parsed["metadata"].get("git_branch", "") or ""
+    git_repo = _git_repo_for_cwd(cwd) or ""
+    git_properties = {k: v for k, v in {"$ai_git_branch": git_branch, "$ai_git_repo": git_repo}.items() if v}
+
     privacy_mode = config.get("privacy_mode", False)
     trace_grouping = config.get("trace_grouping", "session")
     custom_properties = config.get("custom_properties") or None
@@ -127,6 +189,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             output_choices=output_choices,
             user_prompt=user_prompt,
             project_name=project_name,
+            git_properties=git_properties,
             privacy_mode=privacy_mode,
             extra_properties=custom_properties,
             timestamp=gen.get("timestamp"),
@@ -172,6 +235,7 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
             is_error=is_error,
             error_message=error_message,
             project_name=project_name,
+            git_properties=git_properties,
             privacy_mode=privacy_mode,
             max_attribute_length=config.get("max_attribute_length", 12000),
             extra_properties=custom_properties,
@@ -186,9 +250,9 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
 
     # -- $ai_trace events --
     if trace_grouping == "session":
-        _build_session_trace(events, parsed, all_generations, session_trace_id, session_id, project_name, custom_properties)
+        _build_session_trace(events, parsed, all_generations, session_trace_id, session_id, project_name, custom_properties, git_properties)
     else:
-        _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids, custom_properties)
+        _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids, custom_properties, git_properties)
 
     return events
 
@@ -205,7 +269,7 @@ def _compute_latency(timestamps: list[str]) -> Optional[float]:
         return None
 
 
-def _build_session_trace(events, parsed, all_generations, trace_id, session_id, project_name, custom_properties=None):
+def _build_session_trace(events, parsed, all_generations, trace_id, session_id, project_name, custom_properties=None, git_properties=None):
     total_input = sum(g["input_tokens"] for g in all_generations)
     total_output = sum(g["output_tokens"] for g in all_generations)
     has_error = any(g["is_error"] for g in all_generations)
@@ -225,13 +289,14 @@ def _build_session_trace(events, parsed, all_generations, trace_id, session_id, 
         is_error=has_error,
         error_message=error_msg,
         project_name=project_name,
+        git_properties=git_properties,
         extra_properties=custom_properties,
         timestamp=trace_ts,
         insert_id=_insert_id("cc-trace-session", session_id),
     ))
 
 
-def _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids=None, custom_properties=None):
+def _build_message_traces(events, parsed, all_generations, session_id, project_name, fallback_trace_ids=None, custom_properties=None, git_properties=None):
     prompt_generations = {}
     for gen in all_generations:
         pid = gen.get("prompt_id", "")
@@ -261,6 +326,7 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
             is_error=has_error,
             error_message=error_msg,
             project_name=project_name,
+            git_properties=git_properties,
             extra_properties=custom_properties,
             timestamp=prompt_ts,
             insert_id=_insert_id("cc-trace-msg", session_id, pid),
@@ -291,6 +357,7 @@ def _build_message_traces(events, parsed, all_generations, session_id, project_n
                 is_error=has_error,
                 error_message=error_msg,
                 project_name=project_name,
+                git_properties=git_properties,
                 extra_properties=custom_properties,
                 timestamp=timestamps[0] if timestamps else None,
                 insert_id=_insert_id("cc-trace-fallback", session_id, trace_id),

--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -31,6 +31,7 @@ def build_ai_generation(
     user_prompt: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
+    git_properties: Optional[dict] = None,
     privacy_mode: bool = False,
     extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
@@ -75,6 +76,12 @@ def build_ai_generation(
     if user_prompt and not privacy_mode:
         properties["$ai_user_prompt"] = user_prompt
 
+    # Git context lets engineering analytics attribute token spend to PRs by
+    # joining $ai_git_branch against a PR head ref. Already filtered to
+    # truthy values by the caller, so this is a no-op when unknown.
+    if git_properties:
+        properties.update(git_properties)
+
     if extra_properties:
         properties.update(extra_properties)
 
@@ -103,6 +110,7 @@ def build_ai_span(
     error_message: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
+    git_properties: Optional[dict] = None,
     privacy_mode: bool = False,
     max_attribute_length: int = 12000,
     extra_properties: Optional[dict] = None,
@@ -136,6 +144,9 @@ def build_ai_span(
         "$ai_agent_name": agent_name,
     }
 
+    if git_properties:
+        properties.update(git_properties)
+
     if extra_properties:
         properties.update(extra_properties)
 
@@ -162,6 +173,7 @@ def build_ai_trace(
     error_message: Optional[str] = None,
     project_name: str = "",
     agent_name: str = "",
+    git_properties: Optional[dict] = None,
     extra_properties: Optional[dict] = None,
     timestamp: Optional[str] = None,
     insert_id: Optional[str] = None,
@@ -184,6 +196,9 @@ def build_ai_trace(
         "$ai_project_name": project_name,
         "$ai_agent_name": agent_name,
     }
+
+    if git_properties:
+        properties.update(git_properties)
 
     if extra_properties:
         properties.update(extra_properties)

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -11,7 +11,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from posthog_llma.parser import parse_session, find_session_log
-from posthog_llma.event_builder import build_events
+from posthog_llma.event_builder import build_events, parse_git_remote_url
 from posthog_llma.config import load_config
 from posthog_llma.trace_naming import find_trace_name, clean_trace_name
 
@@ -702,6 +702,62 @@ class TestBuildEvents:
         finally:
             os.unlink(path)
 
+    def test_git_metadata_on_all_event_types(self, monkeypatch):
+        # Derive a stable repo so we can assert it without touching real git.
+        monkeypatch.setattr(
+            "posthog_llma.event_builder._git_repo_for_cwd",
+            lambda cwd: "PostHog/ai-plugin",
+        )
+        path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            # Generation, span, and trace must all be present and carry git context.
+            kinds = {e["event"] for e in events}
+            assert {"$ai_generation", "$ai_span", "$ai_trace"} <= kinds
+            for e in events:
+                assert e["properties"]["$ai_git_branch"] == "main"
+                assert e["properties"]["$ai_git_repo"] == "PostHog/ai-plugin"
+        finally:
+            os.unlink(path)
+
+    def test_git_branch_omitted_when_absent(self, monkeypatch):
+        monkeypatch.setattr(
+            "posthog_llma.event_builder._git_repo_for_cwd",
+            lambda cwd: None,
+        )
+        # Session with no gitBranch and no derivable repo.
+        entries = [
+            {"type": "permission-mode", "permissionMode": "default", "sessionId": "s1"},
+            {
+                "type": "user", "uuid": "u-1", "parentUuid": None,
+                "promptId": "p-1", "isMeta": False,
+                "message": {"role": "user", "content": "hi"},
+                "timestamp": "2026-04-12T10:00:00.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+            {
+                "type": "assistant", "uuid": "a-1", "parentUuid": "u-1",
+                "message": {
+                    "role": "assistant", "id": "msg-1",
+                    "model": "claude-opus-4-6", "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 10, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                "timestamp": "2026-04-12T10:00:01.000Z",
+                "sessionId": "s1", "version": "2.1.0", "cwd": "/tmp",
+            },
+        ]
+        path = _write_jsonl(entries)
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            for e in events:
+                assert "$ai_git_branch" not in e["properties"]
+                assert "$ai_git_repo" not in e["properties"]
+        finally:
+            os.unlink(path)
+
     def test_tool_use_blocks_in_output_choices(self):
         path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
         try:
@@ -987,3 +1043,21 @@ class TestLoadConfig:
         finally:
             os.environ.clear()
             os.environ.update(env)
+
+
+class TestParseGitRemoteUrl:
+    @pytest.mark.parametrize("url,expected", [
+        ("git@github.com:PostHog/ai-plugin.git", "PostHog/ai-plugin"),
+        ("git@github.com:PostHog/ai-plugin", "PostHog/ai-plugin"),
+        ("https://github.com/PostHog/ai-plugin.git", "PostHog/ai-plugin"),
+        ("https://github.com/PostHog/ai-plugin", "PostHog/ai-plugin"),
+        ("ssh://git@github.com/PostHog/ai-plugin.git", "PostHog/ai-plugin"),
+        ("https://user@gitlab.com/PostHog/ai-plugin.git", "PostHog/ai-plugin"),
+        ("  git@github.com:PostHog/ai-plugin.git\n", "PostHog/ai-plugin"),
+        ("", None),
+        ("   ", None),
+        ("not-a-url", None),
+        ("git@github.com:justname", None),
+    ])
+    def test_parse(self, url, expected):
+        assert parse_git_remote_url(url) == expected


### PR DESCRIPTION
**Problem**

The parser already reads `gitBranch` from Claude Code transcript entries but drops it before building events, so sessions ingested via llma-cc carry no git context. PostHog engineering analytics attributes LLM token spend to pull requests by joining `$ai_git_branch` against the PR head ref, which makes interactive Claude Code sessions attributable once these properties exist.

**Changes**

All emitted events (`$ai_generation`, `$ai_span`, `$ai_trace`) now carry `$ai_git_branch` (from the transcript) and `$ai_git_repo` (owner/name, best-effort from `git remote get-url origin` in the session's cwd, one subprocess per session). Every failure path just omits the property: missing cwd, non-git dir, no origin, timeout, unparseable remote.

**Testing**

`uv run pytest` green (84 passed), including parameterized remote-URL parsing cases and build-events cases asserting the properties land on all three event types and are absent when unresolvable.

Agent-assisted (Claude Code session, reviewed via a multi-agent simplify pass before push).
