### PR TITLE
fix(codex): skip bash-only write gate on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,4 +22,4 @@ jobs:
         run: python3 -m pip install --user pytest
 
       - name: Run Python tests
-        run: python3 -m pytest tests/test_session_parser.py tests/test_posthog_llma.py
+        run: python3 -m pytest tests/test_session_parser.py tests/test_posthog_llma.py tests/test_hooks_config.py

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -19,6 +19,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/hooks/gate-exec-write.sh",
+            "commandWindows": "cmd /d /c exit 0",
             "timeout": 5
           }
         ]

--- a/tests/test_hooks_config.py
+++ b/tests/test_hooks_config.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_codex_windows_skips_the_bash_only_pre_tool_gate():
+    config = json.loads((ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+    handler = config["hooks"]["PreToolUse"][0]["hooks"][0]
+
+    assert handler["commandWindows"] == "cmd /d /c exit 0"


### PR DESCRIPTION
## Summary

- add a Windows-specific command override for the PostHog `PreToolUse` write gate
- skip the Bash-only gate on Windows Codex, matching the gate script's existing Codex early-exit behavior
- add a regression test for the hook configuration

## Why

On Windows, Codex attempts to launch `hooks/gate-exec-write.sh` before the script can inspect `PLUGIN_ROOT` and take its intended Codex no-op path. Depending on shell resolution, that surfaces as:

    PreToolUse hook (failed)
    hook exited with code 1

The script already deliberately exits successfully under Codex because Codex uses its own approval flow and does not support the hook's `permissionDecision: ask` response. `commandWindows` makes that no-op explicit and avoids requiring Bash just to reach the early exit. Claude Code and non-Windows behavior remain unchanged.

Related: #115 proposes a dedicated Codex approval hook. This change is a narrow fix for the current hook configuration and Windows installations.

## Validation

- Windows Codex 0.144.1 live smoke: `PreToolUse Completed`, followed by a successful PostHog MCP `exec` call
- `tests/test_gate_exec_write.sh`: 45 passed
- Python suite including the new config regression: 72 passed
- JSON parse and `git diff --check`: passed