### PR TITLE
fix: emit $ai_-prefixed cache token properties so ingestion prices cached input

### DIFF
--- a/posthog_llma/events.py
+++ b/posthog_llma/events.py
@@ -69,6 +69,14 @@ def build_ai_generation(
         "$ai_framework": "claude-code",
         "$ai_project_name": project_name,
         "$ai_agent_name": agent_name,
+        # $ai_-prefixed cache properties are what PostHog's ingestion cost
+        # pipeline reads — without them, cached input (the vast majority of
+        # Claude Code request volume) is priced at zero and $ai_total_cost_usd
+        # understates real cost by an order of magnitude on cache-heavy
+        # workloads. Legacy unprefixed names kept for compatibility with
+        # existing queries.
+        "$ai_cache_read_input_tokens": cache_read_tokens,
+        "$ai_cache_creation_input_tokens": cache_creation_tokens,
         "cache_read_input_tokens": cache_read_tokens,
         "cache_creation_input_tokens": cache_creation_tokens,
     }

--- a/tests/test_posthog_llma.py
+++ b/tests/test_posthog_llma.py
@@ -96,6 +96,10 @@ class TestBuildAiGeneration:
             cache_read_tokens=5, cache_creation_tokens=3,
         )
         props = ev["properties"]
+        # $ai_-prefixed names are what PostHog's cost pipeline reads
+        assert props["$ai_cache_read_input_tokens"] == 5
+        assert props["$ai_cache_creation_input_tokens"] == 3
+        # legacy unprefixed names kept for compatibility
         assert props["cache_read_input_tokens"] == 5
         assert props["cache_creation_input_tokens"] == 3
 


### PR DESCRIPTION
## Problem

The Claude Code SessionEnd hook sends cache token counts only under unprefixed property names (`cache_read_input_tokens`, `cache_creation_input_tokens`) — but PostHog's LLM Analytics cost pipeline reads the `$ai_`-prefixed variants (`$ai_cache_read_input_tokens`, `$ai_cache_creation_input_tokens`).

Since Claude Code requests are overwhelmingly cached context (a typical agent turn carries ~200k cached tokens against a handful of uncached input tokens), the effect is large:

- `$ai_total_cost_usd` understates real cost by roughly **10–30×** on cache-heavy sessions
- the Generations list shows input counts like `2` for requests that actually carried hundreds of thousands of cached tokens

Observed on plugin v1.1.49, EU cloud (also reported via the MCP `agent-feedback` channel on 2026-07-13).

## Fix

Emit the two `$ai_`-prefixed properties alongside the existing unprefixed names (kept for compatibility with any queries already built on them). Extended the existing `test_cache_tokens` to assert both spellings — the new assertions fail without the `events.py` change.

`pytest tests/`: 84 passed.