### PR TITLE
feat(llma): emit optional $ai_purpose from POSTHOG_AI_PURPOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
     }
     ```
 
-    Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. Add custom properties to all events with `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON string, e.g. `'{"ai_product": "my-app"}'`).
+    Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. Add custom properties to all events with `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON string, e.g. `'{"ai_product": "my-app"}'`). Set `POSTHOG_AI_PURPOSE` to declare what the session is doing relative to the repo — documented values are `authoring` and `review`, emitted as `$ai_purpose`. Useful when a harness wraps an agent it can't modify (e.g. a CI job running Claude Code as a reviewer); left unset the property is omitted.
 
 ### Cursor
 

--- a/posthog_llma/event_builder.py
+++ b/posthog_llma/event_builder.py
@@ -123,7 +123,18 @@ def build_events(parsed: dict, config: dict) -> list[dict]:
     # a single `properties.update(git_properties)` is a no-op when unknown.
     git_branch = parsed["metadata"].get("git_branch", "") or ""
     git_repo = _git_repo_for_cwd(cwd) or ""
-    git_properties = {k: v for k, v in {"$ai_git_branch": git_branch, "$ai_git_repo": git_repo}.items() if v}
+    # $ai_purpose declares what kind of work this wrapped session is doing
+    # relative to the repo (documented values: "authoring", "review"). Read
+    # from POSTHOG_AI_PURPOSE so a harness that can't modify the agent it
+    # wraps — e.g. a CI job running Claude Code as a reviewer — can declare
+    # it. Absent means unknown; never defaulted. Passed through as-is (only
+    # trimmed and lowercased), no enum enforcement.
+    purpose = os.environ.get("POSTHOG_AI_PURPOSE", "").strip().lower()
+    git_properties = {
+        k: v
+        for k, v in {"$ai_git_branch": git_branch, "$ai_git_repo": git_repo, "$ai_purpose": purpose}.items()
+        if v
+    }
 
     privacy_mode = config.get("privacy_mode", False)
     trace_grouping = config.get("trace_grouping", "session")

--- a/tests/test_session_parser.py
+++ b/tests/test_session_parser.py
@@ -758,6 +758,29 @@ class TestBuildEvents:
         finally:
             os.unlink(path)
 
+    def test_purpose_emitted_when_env_set(self, monkeypatch):
+        # Trimmed and lowercased, passed through without enum enforcement.
+        monkeypatch.setenv("POSTHOG_AI_PURPOSE", "  Review  ")
+        path = _write_jsonl(_make_session())
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            for e in events:
+                assert e["properties"]["$ai_purpose"] == "review"
+        finally:
+            os.unlink(path)
+
+    def test_purpose_absent_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("POSTHOG_AI_PURPOSE", raising=False)
+        path = _write_jsonl(_make_session())
+        try:
+            parsed = parse_session(path, DEFAULT_CONFIG)
+            events = build_events(parsed, DEFAULT_CONFIG)
+            for e in events:
+                assert "$ai_purpose" not in e["properties"]
+        finally:
+            os.unlink(path)
+
     def test_tool_use_blocks_in_output_choices(self):
         path = _write_jsonl(_make_session([{"prompt": "run ls", "tools": ["Bash"]}]))
         try:


### PR DESCRIPTION
Follow-up to #145. The git metadata now says which repo and branch an AI session touched, but not what kind of work it was — authoring code vs reviewing it look identical, so PR-level LLM spend can't be split into "cost to write" vs "cost to review".

This adds an optional `$ai_purpose` property to the llma-cc emission, read from the `POSTHOG_AI_PURPOSE` env var. Documented values are `authoring` and `review`; the value is trimmed and lowercased but not enum-enforced. Unset means the property is omitted entirely — absent means unknown, never defaulted, so events from before this change and unlabeled harnesses stay honest.

An env var (rather than plugin config) is deliberate: the main consumer is a harness wrapping an agent it can't modify, e.g. a CI job running Claude Code as a reviewer just exports the variable in the workflow.

Events are immutable, so purpose can't be backfilled later — landing the stamp early means the split is possible against data accumulating from now on. Consumers (a purpose breakdown on the engineering analytics PR cost tile) come separately.
