### PR TITLE
Add Claude Code marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,37 @@
+{
+  "name": "posthog",
+  "owner": {
+    "name": "PostHog",
+    "email": "hey@posthog.com",
+    "url": "https://posthog.com"
+  },
+  "description": "Official PostHog plugin for AI clients. Access PostHog products directly from your AI coding tool.",
+  "plugins": [
+    {
+      "name": "posthog",
+      "displayName": "PostHog",
+      "source": "./",
+      "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from your AI coding tool. Optionally capture Claude Code sessions to PostHog LLM Analytics.",
+      "version": "1.1.57",
+      "author": {
+        "name": "PostHog",
+        "email": "hey@posthog.com",
+        "url": "https://posthog.com"
+      },
+      "homepage": "https://posthog.com/docs/model-context-protocol",
+      "repository": "https://github.com/PostHog/ai-plugin",
+      "license": "MIT",
+      "category": "productivity",
+      "keywords": [
+        "analytics",
+        "feature-flags",
+        "experiments",
+        "error-tracking",
+        "a/b-testing",
+        "surveys",
+        "dashboards",
+        "llm-analytics"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -106,6 +106,13 @@ jobs:
             fi
           done
 
+          # Keep marketplace.json in sync with plugin.json
+          m=.claude-plugin/marketplace.json
+          if [ -f "$m" ]; then
+            jq --arg v "$(jq -r .version .claude-plugin/plugin.json)" \
+              '.plugins[0].version = $v' "$m" > "$m.tmp" && mv "$m.tmp" "$m"
+          fi
+
           # Regenerate Gemini TOML command files from MD sources
           if [ -x scripts/generate-gemini-commands.sh ]; then
             bash scripts/generate-gemini-commands.sh

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
 
     Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. Add custom properties to all events with `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON string, e.g. `'{"ai_product": "my-app"}'`). Set `POSTHOG_AI_PURPOSE` to declare what the session is doing relative to the repo — documented values are `authoring` and `review`, emitted as `$ai_purpose`. Useful when a harness wraps an agent it can't modify (e.g. a CI job running Claude Code as a reviewer); left unset the property is omitted.
 
+### Claude Cowork
+
+There is no install command — plugins are installed through the UI, separately from Claude Code. Click the **+** button next to the prompt box, select **Plugins** > **Add plugin**, and install **PostHog** from the plugin browser. On first use of a PostHog tool, follow the browser prompts to log into PostHog.
+
 ### Cursor
 
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add manually in Cursor Settings > Plugins.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
 
 ### Claude Cowork
 
-There is no install command — plugins are installed through the UI, separately from Claude Code. Click the **+** button next to the prompt box, select **Plugins** > **Add plugin**, and install **PostHog** from the plugin browser. On first use of a PostHog tool, follow the browser prompts to log into PostHog.
+1. Add the marketplace: open **Settings** > **Plugins**, click **Add** > **Add marketplace**, enter `PostHog/ai-plugin`, and click **Sync**.
+
+2. Install the plugin: click **Browse**, select **PostHog**, and install. The plugin stays in sync with this repo automatically.
+
+3. Authenticate via OAuth: on first use of a PostHog tool, follow the browser prompts to log into PostHog.
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,6 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
 
     Both `POSTHOG_LLMA_CC_ENABLED=true` and `POSTHOG_API_KEY` are required. Sessions are sent when Claude Code exits. Set `POSTHOG_LLMA_PRIVACY_MODE=true` to redact prompt/output content. Add custom properties to all events with `POSTHOG_LLMA_CUSTOM_PROPERTIES` (JSON string, e.g. `'{"ai_product": "my-app"}'`). Set `POSTHOG_AI_PURPOSE` to declare what the session is doing relative to the repo — documented values are `authoring` and `review`, emitted as `$ai_purpose`. Useful when a harness wraps an agent it can't modify (e.g. a CI job running Claude Code as a reviewer); left unset the property is omitted.
 
-### Claude Cowork
-
-1. Add the marketplace: open **Settings** > **Plugins**, click **Add** > **Add marketplace**, enter `PostHog/ai-plugin`, and click **Sync**.
-
-2. Install the plugin: click **Browse**, select **PostHog**, and install. The plugin stays in sync with this repo automatically.
-
-3. Authenticate via OAuth: on first use of a PostHog tool, follow the browser prompts to log into PostHog.
-
 ### Cursor
 
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add manually in Cursor Settings > Plugins.
@@ -83,6 +75,14 @@ gemini extensions install https://github.com/PostHog/ai-plugin
 2. Authenticate via OAuth:
 
     On first use of a PostHog tool, Grok prompts you to authorize in your browser. Log into PostHog to connect.
+
+### Claude Cowork
+
+1. Add the marketplace: open **Settings** > **Plugins**, click **Add** > **Add marketplace**, enter `PostHog/ai-plugin`, and click **Sync**.
+
+2. Install the plugin: click **Browse**, select **PostHog**, and install. The plugin stays in sync with this repo automatically.
+
+3. Authenticate via OAuth: on first use of a PostHog tool, follow the browser prompts to log into PostHog.
 
 ## How to develop
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
     claude plugin install posthog@posthog
     ```
 
-    To get plugin updates automatically with the marketplace method, enable auto-update: run `/plugin` within Claude, open the **Marketplaces** tab, select `posthog`, and choose **Enable auto-update**. Or update manually with `/plugin marketplace update posthog`.
-
 2. Authenticate via OAuth:
     ```bash
     # Just enter Claude Code anywhere

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
 
 1. Install the plugin:
     ```bash
+    claude plugin install posthog
+    ```
+
+    Or install from this repo as a marketplace:
+    ```bash
     claude plugin marketplace add PostHog/ai-plugin
     claude plugin install posthog@posthog
     ```
 
-    To get plugin updates automatically, enable auto-update for the marketplace: run `/plugin` within Claude, open the **Marketplaces** tab, select `posthog`, and choose **Enable auto-update**. Or update manually with `/plugin marketplace update posthog`.
+    To get plugin updates automatically with the marketplace method, enable auto-update: run `/plugin` within Claude, open the **Marketplaces** tab, select `posthog`, and choose **Enable auto-update**. Or update manually with `/plugin marketplace update posthog`.
 
 2. Authenticate via OAuth:
     ```bash

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Official PostHog plugin for AI clients. Access PostHog products directly from yo
 
 1. Install the plugin:
     ```bash
-    claude plugin install posthog
+    claude plugin marketplace add PostHog/ai-plugin
+    claude plugin install posthog@posthog
     ```
+
+    To get plugin updates automatically, enable auto-update for the marketplace: run `/plugin` within Claude, open the **Marketplaces** tab, select `posthog`, and choose **Enable auto-update**. Or update manually with `/plugin marketplace update posthog`.
 
 2. Authenticate via OAuth:
     ```bash


### PR DESCRIPTION
## What changed

- Added `.claude-plugin/marketplace.json` so this repo can be added as a plugin marketplace in Claude Code/Cowork (single entry pointing at the plugin in this repo, matching `plugin.json` name/version).
- Updated the README's Claude Code install steps: the previous `claude plugin install posthog` fails for fresh users because installs resolve only from registered marketplaces. Replaced with the two-step flow:
  ```
  claude plugin marketplace add PostHog/ai-plugin
  claude plugin install posthog@posthog
  ```
- Documented enabling auto-update (off by default for third-party marketplaces) and manual `/plugin marketplace update posthog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)